### PR TITLE
fix(grammars): use target-prefixed objcopy on cross-compile (closes #85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.46.1] - 2026-05-10
+
+### Fixed
+
+- **`panproto-grammars` cross-compile to `aarch64-unknown-linux-gnu`** (`crates/panproto-grammars/build.rs`): `localize_internal_symbols` now resolves the target-prefixed `objcopy` (e.g. `aarch64-linux-gnu-objcopy`) before falling back to plain `objcopy` / `llvm-objcopy`. The host's `x86_64-elf` objcopy could not parse aarch64-elf archive members; symbols went un-renamed and the cross-linker rejected the `panproto-grammars-all` cdylib with `multiple definition of scan/deserialize/scan_comment`. Closes #85.
+
 ## [0.46.0] - 2026-05-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,7 +1975,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "ciborium",
  "panproto-core",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "divan",
  "insta",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "divan",
  "proptest",
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "chumsky",
  "divan",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "divan",
  "miette",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "divan",
  "git2",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "git2",
  "miette",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "cc",
  "divan",
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2226,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2312,7 +2312,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-jit"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "divan",
  "inkwell",
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "divan",
  "insta",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "divan",
  "miette",
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-llvm"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "divan",
  "inkwell",
@@ -2378,7 +2378,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2395,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "divan",
  "memchr",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "blake3",
  "divan",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "blake3",
  "divan",
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2476,7 +2476,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-repl"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "miette",
  "panproto-gat",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "divan",
  "miette",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "blake3",
  "divan",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.46.0"
+version = "0.46.1"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -104,29 +104,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.46.0", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.46.0", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.46.0", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.46.0", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.46.0", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.46.0", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.46.0", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.46.0", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.46.0", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.46.0", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.46.0", path = "crates/panproto-core" }
-panproto-io = { version = "0.46.0", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.46.0", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.46.0", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.46.0", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.46.0", path = "crates/panproto-grammars" }
-panproto-parse = { version = "0.46.0", path = "crates/panproto-parse" }
-panproto-project = { version = "0.46.0", path = "crates/panproto-project" }
-panproto-git = { version = "0.46.0", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.46.0", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.46.0", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.46.0", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.46.0", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.46.1", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.46.1", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.46.1", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.46.1", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.46.1", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.46.1", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.46.1", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.46.1", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.46.1", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.46.1", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.46.1", path = "crates/panproto-core" }
+panproto-io = { version = "0.46.1", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.46.1", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.46.1", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.46.1", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.46.1", path = "crates/panproto-grammars" }
+panproto-parse = { version = "0.46.1", path = "crates/panproto-parse" }
+panproto-project = { version = "0.46.1", path = "crates/panproto-project" }
+panproto-git = { version = "0.46.1", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.46.1", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.46.1", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.46.1", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.46.1", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.46.0
+version:            0.46.1
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.46.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.46.1", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.46.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.46.1", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.46.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.46.1", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.46.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.46.1", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.46.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.46.1", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.46.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.46.1", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.46.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.46.1", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.46.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.46.1", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.46.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.46.1", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.46.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.46.1", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars/build.rs
+++ b/crates/panproto-grammars/build.rs
@@ -323,9 +323,20 @@ fn localize_macos(lib_path: &Path, lib_name: &str, out_dir: &Path, target_arch: 
 
 /// Linux: use objcopy (or llvm-objcopy) with wildcard to keep only
 /// `tree_sitter_*` symbols global in each archive member.
+///
+/// On cross-compile builds the host `objcopy` does not understand the target's
+/// object format (e.g. an x86_64-elf objcopy invoked against an aarch64-elf
+/// archive silently partial-renames symbols, leaving duplicate definitions
+/// that the cross-linker rejects). Prefer the `${TARGET}-objcopy` binary that
+/// cross-toolchains ship (`aarch64-linux-gnu-objcopy`, etc.); fall back to
+/// `objcopy` / `llvm-objcopy` on native builds.
 fn localize_linux(lib_path: &Path) -> bool {
-    // Try objcopy first (GNU binutils), then llvm-objcopy.
-    for tool in &["objcopy", "llvm-objcopy"] {
+    let target = env::var("TARGET").unwrap_or_default();
+    let prefixed = format!("{target}-objcopy");
+
+    let candidates: [&str; 3] = [&prefixed, "objcopy", "llvm-objcopy"];
+
+    for tool in candidates {
         let status = Command::new(tool)
             .args(["--wildcard", "--keep-global-symbol=tree_sitter_*"])
             .arg(lib_path)


### PR DESCRIPTION
## Summary

- `crates/panproto-grammars/build.rs::localize_linux` now resolves the target-prefixed `objcopy` (e.g. `aarch64-linux-gnu-objcopy`) before falling back to plain `objcopy` / `llvm-objcopy`. Unblocks the `panproto-grammars-all` cdylib link on `aarch64-unknown-linux-gnu` cross-compile, which was failing with `multiple definition of scan/deserialize/scan_comment` because the host's `x86_64-elf` objcopy could not parse aarch64-elf archive members.
- Bumps the workspace to **0.46.1** (patch). Cascades through every `workspace.dependencies` entry, the per-group grammar pack `Cargo.toml`s, `bindings/typescript/package.json`, and `bindings/haskell/panproto.cabal`.
- CHANGELOG entry under `## [0.46.1]`.

Closes #85.

## Test plan

- [ ] `cargo nextest run -p panproto-grammars --features group-all` passes on x86_64-linux.
- [ ] `.github/workflows/python-wheels-companions.yml` succeeds on the `all (aarch64-unknown-linux-gnu)` job once tag `v0.46.1` is pushed.
- [ ] Other four target platforms (`x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-pc-windows-msvc`) remain green.
- [ ] Native build (`cargo check -p panproto-grammars`) is unaffected by the prefixed-binary lookup (the `or_else` fallback resolves to plain `objcopy`).