### PR TITLE
docs: bump tree-sitter language count from 248 to 259

### DIFF
--- a/book/src/how-to/parse-full-ast.md
+++ b/book/src/how-to/parse-full-ast.md
@@ -1,6 +1,6 @@
 # Parse full ASTs
 
-panproto can parse source code in 248 languages via tree-sitter and treat the full AST as a schema instance. The resulting instance can be queried, diffed, migrated, and version-controlled like any other schema.
+panproto can parse source code in 259 languages via tree-sitter and treat the full AST as a schema instance. The resulting instance can be queried, diffed, migrated, and version-controlled like any other schema.
 
 ## Prerequisites
 
@@ -56,7 +56,7 @@ Tree-sitter parsing is total: every byte sequence parses into *some* AST. `insta
 ## Common mistakes
 
 - Treating the AST as the source of truth for non-syntactic information. Type information, name resolution, control flow are not modelled by the auto-derived theories.
-- Assuming language coverage. The 248-language list is in [`crates/panproto-grammars/`](https://github.com/panproto/panproto/tree/main/crates/panproto-grammars). Languages not in the list have no parser.
+- Assuming language coverage. The 259-language list is in [`crates/panproto-grammars/`](https://github.com/panproto/panproto/tree/main/crates/panproto-grammars). Languages not in the list have no parser.
 
 ## See also
 

--- a/book/src/reference/crate-map.md
+++ b/book/src/reference/crate-map.md
@@ -24,7 +24,7 @@ The `panproto-*` crates in the workspace, with one-line descriptions and depende
 | Crate | Description |
 |---|---|
 | `panproto-io` | Parse/emit codecs that bridge native formats (JSON, Avro, Protobuf, ...) to `panproto-inst`. |
-| `panproto-parse` | Tree-sitter full-AST parsing across 248 languages, with interstitial preservation. |
+| `panproto-parse` | Tree-sitter full-AST parsing across 259 languages, with interstitial preservation. |
 | `panproto-grammars` | Pre-compiled tree-sitter grammars used by `panproto-parse`. |
 | `panproto-grammars-all` | Umbrella grammar companion pack for the Python wheel. |
 | `panproto-grammars-functional` | Functional-language grammar pack. |

--- a/book/src/reference/protocols.md
+++ b/book/src/reference/protocols.md
@@ -33,7 +33,7 @@ A protocol registration is a sequence of theory colimits applied in a determined
 |---|---|
 | Built-in protocol list | [`crates/panproto-protocols/src/lib.rs`](https://github.com/panproto/panproto/blob/main/crates/panproto-protocols/src/lib.rs) |
 | Building-block theories | [`crates/panproto-protocols/src/theories.rs`](https://github.com/panproto/panproto/blob/main/crates/panproto-protocols/src/theories.rs) |
-| Tree-sitter grammar list (248 languages) | [`crates/panproto-grammars/`](https://github.com/panproto/panproto/tree/main/crates/panproto-grammars) |
+| Tree-sitter grammar list (259 languages) | [`crates/panproto-grammars/`](https://github.com/panproto/panproto/tree/main/crates/panproto-grammars) |
 
 ## Defining a new protocol
 

--- a/book/src/reference/sdk-rust.md
+++ b/book/src/reference/sdk-rust.md
@@ -37,7 +37,7 @@ For lower-level work, depend on individual crates rather than the facade. The [c
 | Write lenses in the lens DSL | `panproto-lens-dsl` |
 | Use the expression language | `panproto-expr`, `panproto-expr-parser` |
 | Version-control schemas and data | `panproto-vcs`, `panproto-git` |
-| Parse full ASTs across 248 languages | `panproto-parse` |
+| Parse full ASTs across 259 languages | `panproto-parse` |
 
 ## See also
 


### PR DESCRIPTION
## Summary

Correctness pass against the Diataxis docs at `book/src/`. The grammar manifest at `grammars.toml` has 259 entries (and `crates/panproto-grammars/Cargo.toml`'s `group-all` lists 259 `lang-*` features); four locations in the book quoted the stale 248.

Files updated:
- `book/src/how-to/parse-full-ast.md` (prose at the top + common-mistakes bullet)
- `book/src/reference/crate-map.md` (`panproto-parse` description)
- `book/src/reference/sdk-rust.md` (sub-crate lookup table)
- `book/src/reference/protocols.md` (source-of-truth table)

No other drift surfaced from the audit (CLI subcommands and flags match the generated `cli.md`; TypeScript / Python SDK references match their respective sources; Rust paths resolve; internal cross-references resolve; v0.47.0 feature mentions are absent because v0.47.0 hasn't merged yet — those updates ride PR #94).

## Test plan

- [ ] `mdbook build book` succeeds with no warnings (already verified locally).
- [ ] `publish-book.yml` deploys on push to main without warnings.
- [ ] Spot-check the four pages in the rendered HTML.