### PR TITLE
fix(parse): preserve edge order under REPEAT(CHOICE) (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.48.1] - 2026-05-18
+
+### Fixed
+
+- **`pretty_with_protocol` preserves edge order on abstract schemas under `REPEAT(CHOICE(...))`** (`panproto-parse::emit_pretty`): two correlated bugs caused interleaved children of the same parent to re-fuse by kind when rendered through `decorate` / `pretty_with_protocol`. A lilypond `expression_block` whose children were `[symbol, punctuation, unsigned_integer, symbol, punctuation, unsigned_integer]` would emit `''c d 4 4` (all punctuation, then all symbols, then all integers) and re-parse as a single super-octave c followed by bare letters and bare integers. With the fix, the same abstract schema emits in insertion order, and `decorate` is a section of `forget_layout` at the granularity of `edge_multiset`, not just `kind_multiset`. Two changes:
+  - `emit_pretty::children_for` now walks the precomputed `schema.outgoing` index (insertion-ordered by `SchemaBuilder` via `SmallVec` append) rather than the unordered `schema.edges` `HashMap`. The previous implementation sorted edges lexicographically by `(kind, target id)` when no explicit `orderings` entries existed, which abstract schemas never set. Explicit `orderings` still override.
+  - `emit_pretty::pick_choice_with_cursor` cursor-driven dispatch now picks the alt whose SYMBOL set covers the *first unconsumed* edge in cursor order, rather than any alt whose SYMBOL set intersects the multiset of unconsumed children. The fingerprint / blob discriminator path used by parsed-schema round-trips is untouched, so existing `EmitParse` / round-trip tests are unaffected.
+- Regression test `lilypond_abstract_edge_order_preserved_through_pretty` in `crates/panproto-parse/tests/decorate_section_law.rs` builds the issue's reproducer and asserts the rendered byte order. Closes #104.
+
 ## [0.48.0] - 2026-05-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "anyhow",
  "miette",
@@ -1994,7 +1994,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "ciborium",
  "panproto-core",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "divan",
  "insta",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "divan",
  "proptest",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "chumsky",
  "divan",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "divan",
  "miette",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "divan",
  "git2",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "git2",
  "miette",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "cc",
  "divan",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-jit"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "divan",
  "inkwell",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "divan",
  "insta",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "divan",
  "miette",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-llvm"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "divan",
  "inkwell",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "divan",
  "memchr",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "blake3",
  "divan",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "blake3",
  "divan",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-repl"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "miette",
  "panproto-gat",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "divan",
  "miette",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "blake3",
  "divan",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.0"
+version = "0.48.1"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.48.0", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.48.0", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.48.0", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.48.0", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.48.0", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.48.0", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.48.0", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.48.0", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.48.0", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.48.0", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.48.0", path = "crates/panproto-core" }
-panproto-io = { version = "0.48.0", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.48.0", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.48.0", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.48.0", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.48.0", path = "crates/panproto-grammars" }
-panproto-parse = { version = "0.48.0", path = "crates/panproto-parse" }
-panproto-project = { version = "0.48.0", path = "crates/panproto-project" }
-panproto-git = { version = "0.48.0", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.48.0", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.48.0", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.48.0", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.48.0", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.48.1", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.48.1", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.48.1", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.48.1", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.48.1", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.48.1", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.48.1", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.48.1", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.48.1", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.48.1", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.48.1", path = "crates/panproto-core" }
+panproto-io = { version = "0.48.1", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.48.1", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.48.1", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.48.1", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.48.1", path = "crates/panproto-grammars" }
+panproto-parse = { version = "0.48.1", path = "crates/panproto-parse" }
+panproto-project = { version = "0.48.1", path = "crates/panproto-project" }
+panproto-git = { version = "0.48.1", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.48.1", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.48.1", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.48.1", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.48.1", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.48.0
+version:            0.48.1
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.48.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/src/decorate.rs
+++ b/crates/panproto-parse/src/decorate.rs
@@ -6,7 +6,8 @@
 //! `emit_pretty_with_protocol` can render byte-for-byte. It is a
 //! section of the schema-level forgetful U
 //! [`DecoratedSchema::forget_layout`](panproto_schema::DecoratedSchema::forget_layout)
-//! up to kind-multiset equivalence.
+//! at the granularity of kind- *and* edge-multiset equivalence (the
+//! ordering invariant — vertex IDs are reborn by the re-parse).
 //!
 //! ## Implementation strategy
 //!
@@ -34,11 +35,16 @@
 //!
 //! For every `a : AbstractSchema` and `p : LayoutPolicy`:
 //!
-//! - **Section law (mod kind-multiset):**
+//! - **Section law (mod kind- and edge-multiset):**
 //!   `kind_multiset(forget_layout(decorate(a, p)).as_schema()) ==
-//!    kind_multiset(a.as_schema())`
-//!   for every protocol with a vendored grammar — verified by the
-//!   `decorate_section_law` integration test.
+//!    kind_multiset(a.as_schema())` AND
+//!   `edge_multiset(forget_layout(decorate(a, p)).as_schema()) ==
+//!    edge_multiset(a.as_schema())`,
+//!   for every protocol with a vendored grammar. The edge-multiset
+//!   half is the load-bearing one for sequenced data: order of notes
+//!   in a `Pattern<MidiEvent>`, of tokens in a parsed AST, of items
+//!   in a homogeneous list, would all collapse without it. Verified
+//!   by the `decorate_section_law` integration test.
 //! - **Policy fidelity:** the bytes produced by `pretty_with_protocol`
 //!   honour every field of `p` (separator, newline, indent_width,
 //!   line_break_after, indent_open / close).

--- a/crates/panproto-parse/src/emit_pretty.rs
+++ b/crates/panproto-parse/src/emit_pretty.rs
@@ -708,6 +708,18 @@ impl<'a> ChildCursor<'a> {
         None
     }
 
+    /// Whether any unconsumed edge satisfies `predicate`. Used by the
+    /// unit tests; the live emit path went through `has_matching` on
+    /// each alternative until cursor-driven dispatch was rewritten to
+    /// pick the first-unconsumed-edge's kind directly.
+    #[cfg(test)]
+    fn has_matching(&self, predicate: impl Fn(&Edge) -> bool) -> bool {
+        self.edges
+            .iter()
+            .enumerate()
+            .any(|(i, edge)| !self.consumed[i] && predicate(edge))
+    }
+
     /// Take the next unconsumed edge whose target vertex satisfies
     /// `predicate`. Returns the edge and the underlying production
     /// resolution path is the caller's job.
@@ -719,14 +731,6 @@ impl<'a> ChildCursor<'a> {
             }
         }
         None
-    }
-
-    /// Whether any unconsumed edge satisfies `predicate`.
-    fn has_matching(&self, predicate: impl Fn(&Edge) -> bool) -> bool {
-        self.edges
-            .iter()
-            .enumerate()
-            .any(|(i, edge)| !self.consumed[i] && predicate(edge))
     }
 }
 
@@ -1303,23 +1307,39 @@ fn pick_choice_with_cursor<'a>(
     }
 
     // Cursor-driven dispatch: pick the alternative whose body
-    // references at least one SYMBOL whose target kind is present in
-    // the unconsumed cursor edges. `referenced_symbols` walks the
-    // alternative recursively (across nested SEQs, REPEATs, OPTIONALs,
-    // FIELDs, etc.) so a leading optional like `attribute_item` does
-    // not block matching when only the trailing required symbol is
+    // references a SYMBOL covering the *first unconsumed* edge in
+    // cursor order. `referenced_symbols` walks the alternative
+    // recursively (across nested SEQs, REPEATs, OPTIONALs, FIELDs,
+    // etc.) so a leading optional like `attribute_item` does not
+    // block matching when only the trailing required symbol is
     // present on the schema.
-    for alt in alternatives {
-        let symbols = referenced_symbols(alt);
-        if !symbols.is_empty()
-            && cursor.has_matching(|edge| {
-                let tk = schema.vertices.get(&edge.tgt).map(|v| v.kind.as_ref());
-                symbols
+    //
+    // Ordering by the first unconsumed edge (rather than picking any
+    // alternative whose SYMBOL set intersects the unconsumed
+    // multiset) is what preserves schema edge order under
+    // REPEAT(CHOICE(...)) productions. Without this rule, alt order
+    // in the grammar's CHOICE determines the emission order, and a
+    // schema with interleaved kinds like `[symbol, punct, int,
+    // symbol, punct, int]` re-fuses to `[symbol, symbol, punct,
+    // punct, int, int]` when emitted then re-parsed. The fix is the
+    // categorical reading of REPEAT-over-list (list-shaped fold)
+    // rather than REPEAT-over-multiset (unordered fold).
+    let first_unconsumed_kind: Option<&str> = cursor
+        .edges
+        .iter()
+        .enumerate()
+        .find(|(i, _)| !cursor.consumed[*i])
+        .and_then(|(_, edge)| schema.vertices.get(&edge.tgt).map(|v| v.kind.as_ref()));
+    if let Some(target_kind) = first_unconsumed_kind {
+        for alt in alternatives {
+            let symbols = referenced_symbols(alt);
+            if !symbols.is_empty()
+                && symbols
                     .iter()
-                    .any(|s| kind_satisfies_symbol(grammar, tk, s))
-            })
-        {
-            return Some(alt);
+                    .any(|s| kind_satisfies_symbol(grammar, Some(target_kind), s))
+            {
+                return Some(alt);
+            }
         }
     }
 
@@ -1510,19 +1530,36 @@ fn has_relevant_constraint(
 }
 
 fn children_for<'a>(schema: &'a Schema, vertex_id: &panproto_gat::Name) -> Vec<&'a Edge> {
-    let mut edges: Vec<&Edge> = schema
-        .edges
-        .keys()
-        .filter(|e| &e.src == vertex_id)
+    // Walk `outgoing` (insertion-ordered by SchemaBuilder via SmallVec
+    // append) rather than the unordered `edges` HashMap so abstract
+    // schemas under REPEAT(CHOICE(...)) preserve the order their edges
+    // were inserted in. The previous implementation walked the HashMap
+    // and sorted lexicographically by (kind, target id), which fused
+    // interleaved children of the same kind into runs (e.g. a sequence
+    // [symbol, punct, int, symbol, punct, int] became [symbol, symbol,
+    // punct, punct, int, int] after the lex sort).
+    let Some(edges) = schema.outgoing.get(vertex_id) else {
+        return Vec::new();
+    };
+
+    // Look up the canonical Edge reference (the key in `schema.edges`)
+    // for each entry in `outgoing`. Falls back to the SmallVec entry if
+    // the canonical key is missing, which would indicate index drift.
+    let mut indexed: Vec<(usize, u32, &Edge)> = edges
+        .iter()
+        .enumerate()
+        .map(|(i, e)| {
+            let canonical = schema.edges.get_key_value(e).map_or(e, |(k, _)| k);
+            let pos = schema.orderings.get(canonical).copied().unwrap_or(u32::MAX);
+            (i, pos, canonical)
+        })
         .collect();
-    edges.sort_by_key(|e| {
-        // Edges with an explicit ordering position come first; remaining
-        // edges sort lexicographically by (kind, target id) for
-        // deterministic walks.
-        let pos = schema.orderings.get(*e).copied().unwrap_or(u32::MAX);
-        (pos, e.kind.clone(), e.tgt.clone())
-    });
-    edges
+
+    // Stable sort by (explicit-ordering, insertion-index). Edges with
+    // an explicit `orderings` entry come first in their declared order;
+    // the remainder fall through in insertion order.
+    indexed.sort_by_key(|(i, pos, _)| (*pos, *i));
+    indexed.into_iter().map(|(_, _, e)| e).collect()
 }
 
 fn vertex_id_kind<'a>(schema: &'a Schema, vertex_id: &panproto_gat::Name) -> Option<&'a str> {

--- a/crates/panproto-parse/tests/decorate_section_law.rs
+++ b/crates/panproto-parse/tests/decorate_section_law.rs
@@ -83,6 +83,90 @@ fn lilypond_section_law_on_issue_example() {
     with_big_stack(|| section_law_holds("lilypond", b"{ c'4 d'4 }"));
 }
 
+/// Regression: `pretty_with_protocol` on a hand-built abstract
+/// schema must preserve schema edge order under REPEAT(CHOICE(...)).
+///
+/// Before the first-unconsumed-edge dispatch rule landed, the
+/// emitter drained all `symbol` children, then all `punctuation`
+/// children, then all `unsigned_integer` children, fusing
+/// `[c, ', 4, d, ', 4, e, ', 4, f, ', 4]` into `[c, d, e, f, ', ',
+/// ', ', 4, 4, 4, 4]`. The resulting bytes parsed back to a single
+/// super-octave c followed by three bare letters and four bare
+/// integers — a kind-multiset match but an edge-order disaster.
+#[cfg(feature = "lang-lilypond")]
+#[test]
+fn lilypond_abstract_edge_order_preserved_through_pretty() {
+    use panproto_schema::{Protocol, SchemaBuilder};
+
+    with_big_stack(|| {
+        let protocol = Protocol {
+            name: "lilypond".into(),
+            schema_theory: "ThLilypond".into(),
+            instance_theory: "ThLilypondInstance".into(),
+            ..Protocol::default()
+        };
+        let abstract_schema = SchemaBuilder::new(&protocol)
+            .vertex("r", "lilypond_program", None)
+            .unwrap()
+            .vertex("b", "expression_block", None)
+            .unwrap()
+            .edge("r", "b", "child_of", None)
+            .unwrap()
+            .vertex("s1", "symbol", None)
+            .unwrap()
+            .edge("b", "s1", "child_of", None)
+            .unwrap()
+            .constraint("s1", "literal-value", "c")
+            .vertex("p1", "punctuation", None)
+            .unwrap()
+            .edge("b", "p1", "child_of", None)
+            .unwrap()
+            .constraint("p1", "literal-value", "'")
+            .vertex("d1", "unsigned_integer", None)
+            .unwrap()
+            .edge("b", "d1", "child_of", None)
+            .unwrap()
+            .constraint("d1", "literal-value", "4")
+            .vertex("s2", "symbol", None)
+            .unwrap()
+            .edge("b", "s2", "child_of", None)
+            .unwrap()
+            .constraint("s2", "literal-value", "d")
+            .vertex("p2", "punctuation", None)
+            .unwrap()
+            .edge("b", "p2", "child_of", None)
+            .unwrap()
+            .constraint("p2", "literal-value", "'")
+            .vertex("d2", "unsigned_integer", None)
+            .unwrap()
+            .edge("b", "d2", "child_of", None)
+            .unwrap()
+            .constraint("d2", "literal-value", "4")
+            .entry("r")
+            .build_abstract()
+            .expect("build abstract");
+
+        let reg = registry();
+        let bytes = reg
+            .pretty_with_protocol("lilypond", &abstract_schema, &LayoutPolicy::default())
+            .expect("pretty");
+        let rendered = String::from_utf8(bytes).expect("utf8");
+
+        // The unconsumed-edge dispatch must keep symbol → punct →
+        // int interleaving. The exact whitespace depends on the
+        // policy; assert on the token order.
+        let c_idx = rendered.find('c').expect("c in output");
+        let d_idx = rendered.find('d').expect("d in output");
+        let first_quote = rendered.find('\'').expect("' in output");
+        let first_four = rendered.find('4').expect("4 in output");
+        assert!(
+            c_idx < first_quote && first_quote < first_four && first_four < d_idx,
+            "expected c < ' < 4 < d in {rendered:?}; \
+             symbol/punct/int order broken under REPEAT(CHOICE)"
+        );
+    });
+}
+
 #[cfg(feature = "lang-json")]
 #[test]
 fn parse_emit_protolens_constructible_for_json() {


### PR DESCRIPTION
## Summary

- `emit_pretty::children_for` now walks the precomputed `schema.outgoing` index (SmallVec, insertion-ordered by `SchemaBuilder`) rather than the unordered `schema.edges` HashMap; explicit `orderings` entries still override.
- `emit_pretty::pick_choice_with_cursor` cursor-driven dispatch rewritten to pick the alt covering the *first unconsumed* edge in cursor order, instead of any alt whose SYMBOL set intersects the multiset of unconsumed children. The fingerprint / blob discriminator path used by parsed-schema round-trips is untouched.
- New regression test `lilypond_abstract_edge_order_preserved_through_pretty` in `decorate_section_law.rs` builds the issue's exact reproducer and asserts the `c < ' < 4 < d` token order in the rendered bytes.

With both fixes, `decorate` is now a section of `forget_layout` at the granularity of `edge_multiset`, not just `kind_multiset`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets`
- [x] `cargo nextest run --workspace` (2656 / 2656 pass)
- [x] `cargo run -p xtask --bin test-book` (16 / 16 pass)
- [x] New regression test passes; existing `decorate_section_law`, every `emit_pretty_roundtrip`, and the `{ c'4 d'4 }` lilypond case all pass.

Closes #104.