### PR TITLE
fix(parse): emit_pretty renders every FIELD(REPEAT(...)) iteration (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.48.2] - 2026-05-18
+
+### Fixed
+
+- **`emit_pretty` renders every iteration of `FIELD(REPEAT(...))` productions** (`panproto-parse::emit_pretty`): the `Field { content: Repeat(...) }` arm called `take_field(name)` once and walked the REPEAT against the consumed child's cursor, so every field-named sibling beyond the first was silently dropped. Tree-sitter's `field('xs', repeat($.X))` produces one field-named edge per match on the parent vertex, so the repetition lives at the parent level. QVR's `program_decl` body — `field('steps', repeat($._program_step))` — was the reported reproducer: a 3-line program with two `sample` steps emitted only one. The fix peels `Repeat` / `Repeat1` off the field content and drives the iteration from the outer cursor, taking one `take_field(name)` edge per iteration; the REPEAT1-minimum fallback still fires when the field is required-but-empty. Regression test: `crates/panproto-parse/tests/emit_pretty_field_repeat.rs::emit_pretty_preserves_every_step_in_field_repeat`. Closes #106.
+
 ## [0.48.1] - 2026-05-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "miette",
@@ -1994,7 +1994,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "ciborium",
  "panproto-core",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "divan",
  "insta",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "divan",
  "proptest",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "chumsky",
  "divan",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "divan",
  "miette",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "divan",
  "git2",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "git2",
  "miette",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "cc",
  "divan",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-jit"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "divan",
  "inkwell",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "divan",
  "insta",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "divan",
  "miette",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-llvm"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "divan",
  "inkwell",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "divan",
  "memchr",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "blake3",
  "divan",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "blake3",
  "divan",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-repl"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "miette",
  "panproto-gat",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "divan",
  "miette",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "blake3",
  "divan",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.1"
+version = "0.48.2"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.48.1", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.48.1", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.48.1", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.48.1", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.48.1", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.48.1", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.48.1", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.48.1", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.48.1", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.48.1", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.48.1", path = "crates/panproto-core" }
-panproto-io = { version = "0.48.1", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.48.1", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.48.1", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.48.1", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.48.1", path = "crates/panproto-grammars" }
-panproto-parse = { version = "0.48.1", path = "crates/panproto-parse" }
-panproto-project = { version = "0.48.1", path = "crates/panproto-project" }
-panproto-git = { version = "0.48.1", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.48.1", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.48.1", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.48.1", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.48.1", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.48.2", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.48.2", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.48.2", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.48.2", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.48.2", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.48.2", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.48.2", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.48.2", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.48.2", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.48.2", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.48.2", path = "crates/panproto-core" }
+panproto-io = { version = "0.48.2", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.48.2", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.48.2", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.48.2", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.48.2", path = "crates/panproto-grammars" }
+panproto-parse = { version = "0.48.2", path = "crates/panproto-parse" }
+panproto-project = { version = "0.48.2", path = "crates/panproto-project" }
+panproto-git = { version = "0.48.2", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.48.2", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.48.2", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.48.2", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.48.2", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.48.1
+version:            0.48.2
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.48.1",
+  "version": "0.48.2",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.1", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/src/emit_pretty.rs
+++ b/crates/panproto-parse/src/emit_pretty.rs
@@ -963,7 +963,37 @@ fn emit_production_inner(
             Ok(())
         }
         Production::Field { name, content } => {
-            if let Some(edge) = cursor.take_field(name) {
+            // Peel a top-level REPEAT / REPEAT1 off the field content
+            // and drive the iteration from the *outer* cursor, taking
+            // one field-named edge per iteration. The naive shape
+            // ("take_field once, walk REPEAT inside that one child's
+            // cursor") loses every sibling beyond the first: tree-
+            // sitter's `field('xs', repeat($.X))` produces one
+            // field-named edge per match on the parent vertex, so the
+            // repetition lives at the parent level, not inside any
+            // single matched child. Without this peel, `program_decl`'s
+            // `field('steps', repeat($._program_step))` body emits
+            // exactly one step and silently drops the rest.
+            let (repeat_inner, at_least_one): (Option<&Production>, bool) = match content.as_ref() {
+                Production::Repeat { content: inner } => (Some(inner.as_ref()), false),
+                Production::Repeat1 { content: inner } => (Some(inner.as_ref()), true),
+                _ => (None, false),
+            };
+            if let Some(inner) = repeat_inner {
+                let mut emitted_any = false;
+                while let Some(edge) = cursor.take_field(name) {
+                    emit_in_child_context(protocol, schema, grammar, &edge.tgt, inner, out)?;
+                    emitted_any = true;
+                }
+                // REPEAT1 minimum: if no field edges existed, fall back
+                // to emitting the inner once with the parent cursor so
+                // a required-but-empty repetition surfaces a token
+                // rather than silently dropping out.
+                if at_least_one && !emitted_any && first_symbol(inner).is_none() {
+                    emit_production(protocol, schema, grammar, vertex_id, inner, cursor, out)?;
+                }
+                Ok(())
+            } else if let Some(edge) = cursor.take_field(name) {
                 emit_in_child_context(protocol, schema, grammar, &edge.tgt, content, out)
             } else if first_symbol(content).is_none() {
                 // FIELD wraps a non-child production (e.g. a literal

--- a/crates/panproto-parse/tests/emit_pretty_field_repeat.rs
+++ b/crates/panproto-parse/tests/emit_pretty_field_repeat.rs
@@ -1,0 +1,57 @@
+//! Regression: `emit_pretty` renders every iteration of a
+//! `FIELD(REPEAT(...))` body, not just the first.
+//!
+//! `program_decl` in the QVR grammar is `seq('program', ..., field('steps',
+//! repeat($._program_step)), $.return_step, ...)`. Before the
+//! `Field { content: Repeat(...) }` carve-out in `emit_pretty.rs`,
+//! the emitter consumed exactly one `steps`-named edge and walked the
+//! REPEAT against that one child's cursor, silently dropping every
+//! other step on the parent vertex.
+//!
+//! This test parses a multi-step program, walks `emit_pretty`, and
+//! checks every step survives.
+
+#![cfg(all(feature = "grammars", feature = "lang-qvr"))]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use panproto_parse::ParserRegistry;
+
+const QVR_MULTI_STEP: &[u8] = b"\
+program p : X -> X:
+    sample a <- f()
+    sample b <- g()
+    return a
+";
+
+#[test]
+fn emit_pretty_preserves_every_step_in_field_repeat() {
+    let reg = ParserRegistry::new();
+    let schema = reg
+        .parse_with_protocol("qvr", QVR_MULTI_STEP, "multi.qvr")
+        .expect("parse");
+
+    let rendered = reg
+        .emit_pretty_with_protocol("qvr", &schema)
+        .expect("emit_pretty");
+    let text = String::from_utf8(rendered).expect("utf8");
+
+    // Every step's terminal tokens must survive. The bug being
+    // closed here is the FIELD(REPEAT) drop: pre-fix output was
+    // `program p: X -> X:\nsample a <- f()\nreturn a\n` (one sample,
+    // not two). Token-order assertions for any one step body are out
+    // of scope — that's the cursor-dispatch problem from #104 surfaced
+    // at a deeper rule than expression_block. Here we only assert the
+    // step *count* is preserved across `FIELD(REPEAT(...))`.
+    let f_calls = text.matches("f(").count();
+    let g_calls = text.matches("g(").count();
+    assert_eq!(
+        f_calls, 1,
+        "first step's function call f() missing from {text:?}"
+    );
+    assert_eq!(
+        g_calls, 1,
+        "second step's function call g() missing from {text:?} \
+         (FIELD(REPEAT) regression: second step was dropped before this fix)"
+    );
+    assert!(text.contains("return"), "return step missing from {text:?}");
+}


### PR DESCRIPTION
## Summary

- `emit_pretty`'s `Field { content: Repeat(...) }` arm consumed exactly one field-named edge and walked the REPEAT body inside that one child's cursor, silently dropping every sibling beyond the first. Tree-sitter's `field('xs', repeat($.X))` produces one field-named edge per match on the *parent* vertex, so the repetition lives at the parent level. QVR's `program_decl` body `field('steps', repeat($._program_step))` was the reported reproducer: a 3-line program with two `sample` steps emitted only one.
- Fix peels `Repeat` / `Repeat1` off the field content and drives the iteration from the outer cursor, taking one `take_field(name)` edge per iteration; the REPEAT1-minimum fallback still fires when the field is required-but-empty.
- New regression test `crates/panproto-parse/tests/emit_pretty_field_repeat.rs` parses a 3-step QVR program and asserts every step survives.
- Workspace patch bump 0.48.1 → 0.48.2; CHANGELOG entry added.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets`
- [x] `cargo nextest run --workspace` (2656 / 2656 pass)
- [x] `cargo run -p xtask --bin test-book` (16 / 16 pass)
- [x] `python3 .github/scripts/check_version_consistency.py --verbose` (OK at 0.48.2)
- [x] New regression test passes; existing decorate_section_law, emit_pretty_roundtrip, and the QVR parse tests all still pass.

Closes #106.