### PR TITLE
fix(parse): emit_pretty handles FIELD(...REPEAT...) at any depth + indent externals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.48.3] - 2026-05-19
+
+### Fixed
+
+- **`emit_pretty` renders every iteration of repetition inside a `FIELD(...)` body, not only top-level `FIELD(REPEAT(...))`** (`panproto-parse::emit_pretty`): the previous fix peeled `Repeat` / `Repeat1` off the top of a FIELD's content, which handled `field('steps', repeat($._program_step))` but not `field('args', commaSep1($._draw_arg))` — the latter expands to `FIELD(SEQ(SYMBOL X, REPEAT(SEQ(',', SYMBOL X))))` and the SEQ wrapper defeated the peel. The inner REPEAT then walked the first consumed child's cursor (which has no sibling field edges) and broke after one iteration. The fix moves the field hint into a thread-local `EMIT_FIELD_CONTEXT` that the SYMBOL handler consults: when set, every SYMBOL under the FIELD body — at any depth, under SEQ / CHOICE / REPEAT / REPEAT1 / OPTIONAL / ALIAS — consumes successive edges via `take_field(name)` on the outer cursor instead of `take_symbol_match` against the inner. The new path subsumes the prior carve-outs for FIELD(REPEAT(...)), FIELD(REPEAT1(...)), and bare FIELD(SYMBOL ...). FIELD content with no SYMBOL (e.g. `field('op', '+')`, `field('op', CHOICE(STRING, STRING))`) still emits its literals: STRING handlers ignore the context.
+- **`emit_pretty` opens and closes indent scopes for grammars with `_indent` / `_dedent` external scanner tokens** (`panproto-parse::emit_pretty`): the SYMBOL handler's external-token fallback covered `*newline*` / `*line_ending*` / `*_or_eof` but ignored `*_indent` and `*_dedent`. For indent-based grammars (Python, YAML, and QVR-flavoured indent grammars whose vendored generation surfaces `_indent`/`_dedent` as externals) the rendered output was structurally well-formed but unparseable: the parser expected an INDENT token after `:` and got a content character at column 0. The fallback now dispatches `_indent` / `*_indent` to `Output::indent_open` and `_dedent` / `*_dedent` to `Output::indent_close`, reusing the existing indent-depth machinery the format policy already drives for `{` / `}` token pairs. Other external tokens still fall through silently.
+- Regression test `crates/panproto-parse/tests/emit_pretty_field_repeat.rs::emit_pretty_preserves_every_arg_in_field_commasep1` parses `f(1.0, 2.0, 3.0)` through a `commaSep1` field and asserts every arg survives `emit_pretty`. The pre-existing `emit_pretty_preserves_every_step_in_field_repeat` continues to cover the simpler `FIELD(REPEAT(SYMBOL))` shape.
+
 ## [0.48.2] - 2026-05-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "anyhow",
  "miette",
@@ -1994,7 +1994,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "ciborium",
  "panproto-core",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "divan",
  "insta",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "divan",
  "proptest",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "chumsky",
  "divan",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "divan",
  "miette",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "divan",
  "git2",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "git2",
  "miette",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "cc",
  "divan",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-jit"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "divan",
  "inkwell",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "divan",
  "insta",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "divan",
  "miette",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-llvm"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "divan",
  "inkwell",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "divan",
  "memchr",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "blake3",
  "divan",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "blake3",
  "divan",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-repl"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "miette",
  "panproto-gat",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "divan",
  "miette",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "blake3",
  "divan",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.48.2"
+version = "0.48.3"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.2"
+version = "0.48.3"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.48.2", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.48.2", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.48.2", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.48.2", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.48.2", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.48.2", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.48.2", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.48.2", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.48.2", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.48.2", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.48.2", path = "crates/panproto-core" }
-panproto-io = { version = "0.48.2", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.48.2", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.48.2", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.48.2", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.48.2", path = "crates/panproto-grammars" }
-panproto-parse = { version = "0.48.2", path = "crates/panproto-parse" }
-panproto-project = { version = "0.48.2", path = "crates/panproto-project" }
-panproto-git = { version = "0.48.2", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.48.2", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.48.2", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.48.2", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.48.2", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.48.3", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.48.3", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.48.3", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.48.3", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.48.3", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.48.3", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.48.3", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.48.3", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.48.3", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.48.3", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.48.3", path = "crates/panproto-core" }
+panproto-io = { version = "0.48.3", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.48.3", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.48.3", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.48.3", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.48.3", path = "crates/panproto-grammars" }
+panproto-parse = { version = "0.48.3", path = "crates/panproto-parse" }
+panproto-project = { version = "0.48.3", path = "crates/panproto-project" }
+panproto-git = { version = "0.48.3", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.48.3", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.48.3", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.48.3", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.48.3", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.48.2
+version:            0.48.3
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.48.2",
+  "version": "0.48.3",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.48.3", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.48.3", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.48.3", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.48.3", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.48.3", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.48.3", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.48.3", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.48.3", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.48.3", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.2", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.48.3", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/src/emit_pretty.rs
+++ b/crates/panproto-parse/src/emit_pretty.rs
@@ -747,6 +747,47 @@ thread_local! {
     /// `_expression` ⊃ `binary_expression` ⊃ `_expression`.
     static EMIT_MU_FRAMES: std::cell::RefCell<std::collections::HashSet<(String, String)>> =
         std::cell::RefCell::new(std::collections::HashSet::new());
+    /// The name of the FIELD whose body the walker is currently inside,
+    /// or `None` at top level. Lets a SYMBOL nested arbitrarily deep
+    /// in the field's content (under SEQ, CHOICE, REPEAT, OPTIONAL)
+    /// consume from the *outer* cursor by edge-kind rather than from
+    /// the child's own cursor by symbol-match. Without this, shapes
+    /// like `field('args', commaSep1($.X))` — which expands to
+    /// `FIELD(SEQ(SYMBOL X, REPEAT(SEQ(',', SYMBOL X))))` — emit only
+    /// the first matched edge: the FIELD handler consumed one edge,
+    /// the inner REPEAT searched the consumed child's cursor (which
+    /// has no more sibling field edges), and the REPEAT broke after
+    /// one iteration. Setting the context here so the inner SYMBOL
+    /// pulls successive field-named edges from the outer cursor
+    /// recovers every matched edge across arbitrary nesting.
+    static EMIT_FIELD_CONTEXT: std::cell::RefCell<Option<String>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// RAII guard that restores the prior `EMIT_FIELD_CONTEXT` value on drop.
+struct FieldContextGuard(Option<String>);
+
+impl Drop for FieldContextGuard {
+    fn drop(&mut self) {
+        EMIT_FIELD_CONTEXT.with(|f| *f.borrow_mut() = self.0.take());
+    }
+}
+
+fn push_field_context(name: &str) -> FieldContextGuard {
+    let prev = EMIT_FIELD_CONTEXT.with(|f| f.borrow_mut().replace(name.to_owned()));
+    FieldContextGuard(prev)
+}
+
+/// Clear the field context for the duration of a child-context walk.
+/// The child's own production has its own FIELDs that set their own
+/// context; the outer field hint must not leak into them.
+fn clear_field_context() -> FieldContextGuard {
+    let prev = EMIT_FIELD_CONTEXT.with(|f| f.borrow_mut().take());
+    FieldContextGuard(prev)
+}
+
+fn current_field_context() -> Option<String> {
+    EMIT_FIELD_CONTEXT.with(|f| f.borrow().clone())
 }
 
 /// Walk a rule at a vertex inside a μ-binder. The wrapping frame is
@@ -834,6 +875,28 @@ fn emit_production_inner(
         }
         Production::Blank => Ok(()),
         Production::Symbol { name } => {
+            // Inside a FIELD body, a SYMBOL consumes by field-name on
+            // the outer cursor rather than searching by symbol-match.
+            // This covers the simple `FIELD(SYMBOL X)` case as well as
+            // every nesting under FIELD that contains SYMBOLs (SEQ,
+            // CHOICE, REPEAT, OPTIONAL, ALIAS). Without the override,
+            // shapes like `field('args', commaSep1($.X))` consume one
+            // field edge in the FIELD handler and then the REPEAT
+            // inside SEQ searches the consumed child's cursor — where
+            // no sibling field edges sit — and breaks after one
+            // iteration.
+            if let Some(field) = current_field_context() {
+                if let Some(edge) = cursor.take_field(&field) {
+                    return emit_in_child_context(
+                        protocol, schema, grammar, &edge.tgt, production, out,
+                    );
+                }
+                // No matching field-named edge left on the outer
+                // cursor. Surface nothing; the surrounding REPEAT /
+                // OPTIONAL / CHOICE backtracks the literal tokens it
+                // emitted on this iteration when it sees no progress.
+                return Ok(());
+            }
             if name.starts_with('_') {
                 // Hidden rule: not a vertex kind on the schema side.
                 // Inline-expand the rule body so its children take
@@ -855,14 +918,31 @@ fn emit_production_inner(
                 } else {
                     // External hidden rule (declared in the
                     // grammar's `externals` block, scanned by C code,
-                    // not listed in `rules`). Heuristic fallback:
-                    // line-ending / EOF externals are universally
-                    // newline-or-empty, so emitting a single newline
-                    // is the right default for grammars like TOML
-                    // whose `pair` SEQ trails into
-                    // `_line_ending_or_eof`. Anything else falls
-                    // through silently.
-                    if name.contains("line_ending")
+                    // not listed in `rules`). Heuristic fallback by
+                    // name:
+                    //
+                    // - `_indent` / `*_indent`: open an indent block.
+                    //   Indent-based grammars (Python, YAML, qvr)
+                    //   declare an `_indent` external scanner before
+                    //   the body of a block-bodied declaration; the
+                    //   emitted output is unparseable without the
+                    //   corresponding indentation jump.
+                    // - `_dedent` / `*_dedent`: close the matching
+                    //   indent block.
+                    // - `_newline` / `*_line_ending` / `*_or_eof`:
+                    //   universally newline-or-empty; emitting a
+                    //   single newline is the right default for
+                    //   grammars like TOML whose `pair` SEQ trails
+                    //   into `_line_ending_or_eof`.
+                    //
+                    // Anything else falls through silently — better
+                    // to drop an unknown external token than to
+                    // invent one that confuses re-parsing.
+                    if name == "_indent" || name.ends_with("_indent") {
+                        out.indent_open();
+                    } else if name == "_dedent" || name.ends_with("_dedent") {
+                        out.indent_close();
+                    } else if name.contains("line_ending")
                         || name.contains("newline")
                         || name.ends_with("_or_eof")
                     {
@@ -963,50 +1043,26 @@ fn emit_production_inner(
             Ok(())
         }
         Production::Field { name, content } => {
-            // Peel a top-level REPEAT / REPEAT1 off the field content
-            // and drive the iteration from the *outer* cursor, taking
-            // one field-named edge per iteration. The naive shape
-            // ("take_field once, walk REPEAT inside that one child's
-            // cursor") loses every sibling beyond the first: tree-
-            // sitter's `field('xs', repeat($.X))` produces one
-            // field-named edge per match on the parent vertex, so the
-            // repetition lives at the parent level, not inside any
-            // single matched child. Without this peel, `program_decl`'s
-            // `field('steps', repeat($._program_step))` body emits
-            // exactly one step and silently drops the rest.
-            let (repeat_inner, at_least_one): (Option<&Production>, bool) = match content.as_ref() {
-                Production::Repeat { content: inner } => (Some(inner.as_ref()), false),
-                Production::Repeat1 { content: inner } => (Some(inner.as_ref()), true),
-                _ => (None, false),
-            };
-            if let Some(inner) = repeat_inner {
-                let mut emitted_any = false;
-                while let Some(edge) = cursor.take_field(name) {
-                    emit_in_child_context(protocol, schema, grammar, &edge.tgt, inner, out)?;
-                    emitted_any = true;
-                }
-                // REPEAT1 minimum: if no field edges existed, fall back
-                // to emitting the inner once with the parent cursor so
-                // a required-but-empty repetition surfaces a token
-                // rather than silently dropping out.
-                if at_least_one && !emitted_any && first_symbol(inner).is_none() {
-                    emit_production(protocol, schema, grammar, vertex_id, inner, cursor, out)?;
-                }
-                Ok(())
-            } else if let Some(edge) = cursor.take_field(name) {
-                emit_in_child_context(protocol, schema, grammar, &edge.tgt, content, out)
-            } else if first_symbol(content).is_none() {
-                // FIELD wraps a non-child production (e.g. a literal
-                // STRING operator like `+` in a binary_expression, or
-                // a CHOICE of STRING tokens). The walker captures
-                // these as interstitials rather than vertices, so the
-                // schema has no field edge to consume; emit the
-                // content in place so the operator / keyword survives
-                // the round-trip.
-                emit_production(protocol, schema, grammar, vertex_id, content, cursor, out)
-            } else {
-                Ok(())
-            }
+            // Set the field context for the duration of `content`'s
+            // walk and emit the content against the *outer* cursor.
+            // The SYMBOL handler picks up the context and pulls
+            // successive `take_field(name)` edges as it encounters
+            // SYMBOLs anywhere under `content` (under SEQ, CHOICE,
+            // REPEAT, OPTIONAL, ALIAS — arbitrarily nested). This
+            // subsumes the prior carve-outs for FIELD(REPEAT(...)),
+            // FIELD(REPEAT1(...)), and the bare FIELD(SYMBOL ...)
+            // case, and adds coverage for
+            // `field('xs', commaSep1($.X))` which expands to
+            // FIELD(SEQ(SYMBOL X, REPEAT(SEQ(',', SYMBOL X)))) and
+            // any other shape where REPEAT/REPEAT1 sits inside SEQ /
+            // CHOICE / OPTIONAL under a FIELD. A FIELD that wraps a
+            // non-SYMBOL production (e.g. `field('op', '+')` or
+            // `field('op', CHOICE(STRING ...))`) still works: STRING
+            // handlers ignore the context and emit literals
+            // directly, so the operator token survives the round
+            // trip.
+            let _guard = push_field_context(name);
+            emit_production(protocol, schema, grammar, vertex_id, content, cursor, out)
         }
         Production::Alias {
             content,
@@ -1172,6 +1228,12 @@ fn emit_in_child_context(
     production: &Production,
     out: &mut Output<'_>,
 ) -> Result<(), ParseError> {
+    // The child walks under its own production tree, with its own
+    // FIELDs setting their own contexts. Clear the outer FIELD hint
+    // so it does not leak through and cause sibling SYMBOLs inside
+    // the child's body to mistakenly pull edges from the child's
+    // cursor by the parent's field name.
+    let _guard = clear_field_context();
     // If `production` is a structural wrapper (CHOICE / SEQ /
     // OPTIONAL / ...) whose referenced symbols cover the child's own
     // kind, the child IS the production's target node and the right
@@ -1480,6 +1542,7 @@ fn referenced_symbols(production: &Production) -> Vec<&str> {
     out
 }
 
+#[cfg(test)]
 fn first_symbol(production: &Production) -> Option<&str> {
     match production {
         Production::Symbol { name } => Some(name),
@@ -1727,6 +1790,20 @@ impl<'a> Output<'a> {
 
     fn newline(&mut self) {
         self.tokens.push(Token::LineBreak);
+    }
+
+    /// Open an indent scope: subsequent `LineBreak`s render at the
+    /// new depth until a matching `indent_close` pops it. Used by the
+    /// external-token fallback to render indent-based grammars'
+    /// `_indent` scanner outputs.
+    fn indent_open(&mut self) {
+        self.tokens.push(Token::IndentOpen);
+        self.tokens.push(Token::LineBreak);
+    }
+
+    /// Close one indent scope opened by `indent_open`.
+    fn indent_close(&mut self) {
+        self.tokens.push(Token::IndentClose);
     }
 
     fn snapshot(&self) -> OutputSnapshot {

--- a/crates/panproto-parse/tests/emit_pretty_field_repeat.rs
+++ b/crates/panproto-parse/tests/emit_pretty_field_repeat.rs
@@ -1,5 +1,17 @@
-//! Regression: `emit_pretty` renders every iteration of a
-//! `FIELD(REPEAT(...))` body, not just the first.
+//! Regression: `emit_pretty` renders every iteration of repetition
+//! inside a `FIELD(...)` body, not just the first.
+//!
+//! Two correlated shapes are exercised:
+//!
+//! - `FIELD(REPEAT(SYMBOL))` directly: `program_decl`'s
+//!   `field('steps', repeat($._program_step))`.
+//! - `FIELD(SEQ(SYMBOL, REPEAT(SEQ(STRING, SYMBOL))))`: the
+//!   `commaSep1` shape that `field('args', commaSep1($._draw_arg))`
+//!   expands to. The previous fix only peeled top-level
+//!   `REPEAT`/`REPEAT1` off the field content; the SEQ wrapper in
+//!   `commaSep1` defeated the peel and the inner REPEAT still walked
+//!   inside the first consumed child's cursor, dropping every
+//!   sibling arg beyond the first.
 //!
 //! `program_decl` in the QVR grammar is `seq('program', ..., field('steps',
 //! repeat($._program_step)), $.return_step, ...)`. Before the
@@ -54,4 +66,37 @@ fn emit_pretty_preserves_every_step_in_field_repeat() {
          (FIELD(REPEAT) regression: second step was dropped before this fix)"
     );
     assert!(text.contains("return"), "return step missing from {text:?}");
+}
+
+/// Multiple args in a `commaSep1`-shaped field must all survive
+/// `emit_pretty`. `field('args', commaSep1($._draw_arg))` expands to
+/// `FIELD(SEQ(SYMBOL X, REPEAT(SEQ(',', SYMBOL X))))`. Pre-fix, the
+/// inner REPEAT searched the first consumed child's cursor for more
+/// args, found none, and broke after one iteration. With the
+/// field-context override, the SYMBOLs under the FIELD body pull
+/// successive `take_field("args")` edges from the outer cursor.
+const QVR_MULTI_ARG: &[u8] = b"\
+program p : X -> X:
+    sample a <- f(1.0, 2.0, 3.0)
+    return a
+";
+
+#[test]
+fn emit_pretty_preserves_every_arg_in_field_commasep1() {
+    let reg = ParserRegistry::new();
+    let schema = reg
+        .parse_with_protocol("qvr", QVR_MULTI_ARG, "args.qvr")
+        .expect("parse");
+
+    let rendered = reg
+        .emit_pretty_with_protocol("qvr", &schema)
+        .expect("emit_pretty");
+    let text = String::from_utf8(rendered).expect("utf8");
+
+    for arg in ["1.0", "2.0", "3.0"] {
+        assert!(
+            text.contains(arg),
+            "rendered output is missing arg {arg:?}; commaSep1 regression: {text:?}",
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Two correlated `emit_pretty` bugs that the previous FIELD(REPEAT(...)) carve-out missed:

**1. FIELD body with nested repetition (commaSep1 shape).** The previous fix peeled top-level `Repeat` / `Repeat1` off a FIELD's content. That handled `field('steps', repeat($._program_step))` but not `field('args', commaSep1($._draw_arg))`, whose tree-sitter expansion is `FIELD(SEQ(SYMBOL X, REPEAT(SEQ(',', SYMBOL X))))`. The SEQ wrapper defeated the peel and `f(1.0, 2.0, 3.0)` came out as `f(1.0)`. The new shape is general: move the field hint into a thread-local `EMIT_FIELD_CONTEXT` and have the SYMBOL handler consume `take_field(name)` from the outer cursor at any depth (SEQ / CHOICE / REPEAT / REPEAT1 / OPTIONAL / ALIAS). This subsumes the prior carve-outs for `FIELD(REPEAT(...))`, `FIELD(REPEAT1(...))`, and bare `FIELD(SYMBOL ...)`.

**2. Indent-based grammars.** The SYMBOL handler's external-token fallback covered `newline` / `line_ending` / `_or_eof` but not `_indent` / `_dedent`. The rendered output was structurally well-formed but unparseable: the parser expected an INDENT token after `:` and got a content character at column 0. The fallback now dispatches `_indent` / `*_indent` to `Output::indent_open` and `_dedent` / `*_dedent` to `Output::indent_close`, reusing the indent-depth machinery the format policy already drives for `{` / `}` token pairs.

Regression test `crates/panproto-parse/tests/emit_pretty_field_repeat.rs::emit_pretty_preserves_every_arg_in_field_commasep1` parses `f(1.0, 2.0, 3.0)` through a `commaSep1` field and asserts every arg survives `emit_pretty`. The pre-existing `emit_pretty_preserves_every_step_in_field_repeat` continues to cover the simpler `FIELD(REPEAT(SYMBOL))` shape.

Bumps workspace version 0.48.2 → 0.48.3. CHANGELOG entry added.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets`
- [x] `cargo nextest run --workspace` (2656 / 2656 pass)
- [x] `cargo run -p xtask --bin test-book` (16 / 16 pass)
- [x] `python3 .github/scripts/check_version_consistency.py --verbose` (OK at 0.48.3)