### PR TITLE
fix(parse): stop leaking group-core into every group consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.48.5] - 2026-05-21
+
+### Fixed
+
+- **`panproto-parse`'s `grammars` feature no longer drags `panproto-grammars/default` into every consumer** (`crates/panproto-parse/Cargo.toml`): the `grammars` feature previously activated `panproto-grammars/default`, which in turn activated `panproto-grammars/group-core` (11 mainstream-programming grammars: bash, c, cpp, csharp, go, java, javascript, php, python, rust, typescript). Every `group-*` feature on panproto-parse inherits `grammars`, so a downstream consumer asking for `group-music + lang-haskell` ended up with 20 grammars instead of 9, including 11 unused for music applications. Downstream `default-features = false` on a direct `panproto-grammars` dep could not opt out, because panproto-parse's transitive activation re-enabled the default. Now `grammars` only activates the optional dep; group activation goes through the explicit `panproto-grammars/group-*` feature; the workspace `panproto-grammars` dependency is declared with `default-features = false` so the inner crate's own `default = ["group-core"]` does not leak transitively either. The user-visible behavior of `cargo add panproto-parse` is unchanged: `default` on panproto-parse now lists `group-core` directly, so top-level consumers still get the 11 mainstream grammars without configuration. Consumers who previously wrote `default-features = false, features = ["grammars"]` and expected `group-core` must switch to `features = ["group-core"]`. Closes #114.
+
 ## [0.48.4] - 2026-05-19
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "anyhow",
  "miette",
@@ -1994,7 +1994,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "ciborium",
  "panproto-core",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "divan",
  "insta",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "divan",
  "proptest",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "chumsky",
  "divan",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "divan",
  "miette",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "divan",
  "git2",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "git2",
  "miette",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "cc",
  "divan",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-jit"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "divan",
  "inkwell",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "divan",
  "insta",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "divan",
  "miette",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-llvm"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "divan",
  "inkwell",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "divan",
  "memchr",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "blake3",
  "divan",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "blake3",
  "divan",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-repl"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "miette",
  "panproto-gat",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "divan",
  "miette",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "blake3",
  "divan",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.48.4"
+version = "0.48.5"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.4"
+version = "0.48.5"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.48.4", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.48.4", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.48.4", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.48.4", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.48.4", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.48.4", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.48.4", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.48.4", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.48.4", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.48.4", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.48.4", path = "crates/panproto-core" }
-panproto-io = { version = "0.48.4", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.48.4", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.48.4", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.48.4", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.48.4", path = "crates/panproto-grammars" }
-panproto-parse = { version = "0.48.4", path = "crates/panproto-parse" }
-panproto-project = { version = "0.48.4", path = "crates/panproto-project" }
-panproto-git = { version = "0.48.4", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.48.4", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.48.4", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.48.4", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.48.4", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.48.5", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.48.5", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.48.5", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.48.5", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.48.5", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.48.5", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.48.5", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.48.5", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.48.5", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.48.5", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.48.5", path = "crates/panproto-core" }
+panproto-io = { version = "0.48.5", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.48.5", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.48.5", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.48.5", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.48.5", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.48.5", path = "crates/panproto-parse" }
+panproto-project = { version = "0.48.5", path = "crates/panproto-project" }
+panproto-git = { version = "0.48.5", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.48.5", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.48.5", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.48.5", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.48.5", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.48.4
+version:            0.48.5
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.48.4",
+  "version": "0.48.5",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.4", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.4", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.4", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.48.4", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.4", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.4", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.4", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.4", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.4", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.4", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/Cargo.toml
+++ b/crates/panproto-parse/Cargo.toml
@@ -39,8 +39,8 @@ name = "parse_real_protobuf"
 required-features = ["lang-protobuf"]
 
 [features]
-default = ["grammars"]
-grammars = ["dep:panproto-grammars", "panproto-grammars/default"]
+default = ["group-core"]
+grammars = ["dep:panproto-grammars"]
 group-core = ["grammars", "panproto-grammars/group-core"]
 group-web = ["grammars", "panproto-grammars/group-web"]
 group-systems = ["grammars", "panproto-grammars/group-systems"]


### PR DESCRIPTION
## Summary

- `panproto-parse`'s `grammars` feature was force-activating `panproto-grammars/default` (= `group-core`, 11 mainstream grammars). Every `group-*` feature inherits `grammars`, so a downstream `group-music + lang-haskell` consumer got 20 grammars instead of 9, and could not opt out via `default-features = false`.
- `grammars` now only activates the optional dep. Workspace `panproto-grammars` dep is declared with `default-features = false`. Top-level default behaviour unchanged: panproto-parse's `default` now lists `group-core` directly.
- Bump workspace to 0.48.5.

Closes #114.

## Test plan
- [x] `cargo run` from a downstream crate with `default-features = false, features = ["group-music"]` lists exactly 8 protocols (`abc`, `chuck`, `csound`, `glicol`, `lilypond`, `strudel_mini`, `supercollider`, `tidal_mini`) — no leak.
- [x] `cargo run` from a downstream crate with default features lists the original group-core grammars (`bash`, `c`, `cpp`, ...) — unchanged.
- [ ] CI: clippy, nextest, fmt, version consistency.