### PR TITLE
fix(parse): keep tight unary prefixes glued in emit_pretty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.48.6] - 2026-05-21
+
+### Fixed
+
+- **`emit_pretty` keeps tight unary prefixes glued to their operand** (`panproto-parse::emit_pretty`): the layout pass inserted the default separator between any `-` / `+` / `!` / `~` and the following token, turning `f(-1.0)` into `f(- 1.0)`. The split parses as a different AST (unary minus applied to a positive literal) rather than as a single signed literal, so the round-trip was semantically lossy on every grammar with a `signed_number` (or analogous) production. The pass now tracks an `expecting_operand` flag along the token stream: at start of stream / line, after open punctuation, after a separator (`,` / `;`), and after another operator-run, the cursor is in operand position. When the previous token was emitted in operand position and is one of `-` / `+` / `!` / `~`, it is recognised as a tight unary prefix and glues to the following operand. Binary `a - b` keeps its spaces because the cursor was not in operand position when `-` was emitted. Regression test at `crates/panproto-parse/tests/emit_pretty_signed_number.rs`. Closes #111.
+
 ## [0.48.5] - 2026-05-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.5"
+version = "0.48.6"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.48.5", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.48.5", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.48.5", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.48.5", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.48.5", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.48.5", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.48.5", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.48.5", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.48.5", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.48.5", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.48.5", path = "crates/panproto-core" }
-panproto-io = { version = "0.48.5", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.48.5", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.48.5", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.48.5", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.48.5", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.48.5", path = "crates/panproto-parse" }
-panproto-project = { version = "0.48.5", path = "crates/panproto-project" }
-panproto-git = { version = "0.48.5", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.48.5", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.48.5", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.48.5", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.48.5", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.48.6", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.48.6", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.48.6", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.48.6", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.48.6", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.48.6", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.48.6", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.48.6", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.48.6", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.48.6", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.48.6", path = "crates/panproto-core" }
+panproto-io = { version = "0.48.6", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.48.6", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.48.6", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.48.6", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.48.6", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.48.6", path = "crates/panproto-parse" }
+panproto-project = { version = "0.48.6", path = "crates/panproto-project" }
+panproto-git = { version = "0.48.6", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.48.6", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.48.6", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.48.6", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.48.6", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.48.5
+version:            0.48.6
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.48.5",
+  "version": "0.48.6",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.5", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/src/emit_pretty.rs
+++ b/crates/panproto-parse/src/emit_pretty.rs
@@ -1831,6 +1831,14 @@ fn layout(tokens: &[Token], policy: &FormatPolicy) -> Vec<u8> {
     let mut indent: usize = 0;
     let mut at_line_start = true;
     let mut last_lit: Option<&str> = None;
+    // True iff, at the moment `last_lit` was emitted, the cursor was at a
+    // position where the grammar expects an operand: start of stream / line,
+    // just after an open paren / bracket / brace, just after a separator like
+    // `,` or `;`, or just after a binary / assignment operator. Used by
+    // `needs_space_between` to recognise `last_lit` as a tight unary prefix
+    // (`f(-1.0)`) rather than a spaced binary operator (`a - b`).
+    let mut last_was_in_operand_position = true;
+    let mut expecting_operand = true;
     let newline = policy.newline.as_bytes();
     let separator = policy.separator.as_bytes();
 
@@ -1842,24 +1850,28 @@ fn layout(tokens: &[Token], policy: &FormatPolicy) -> Vec<u8> {
                 if !at_line_start {
                     bytes.extend_from_slice(newline);
                     at_line_start = true;
+                    expecting_operand = true;
                 }
             }
             Token::LineBreak => {
                 if !at_line_start {
                     bytes.extend_from_slice(newline);
                     at_line_start = true;
+                    expecting_operand = true;
                 }
             }
             Token::Lit(value) => {
                 if at_line_start {
                     bytes.extend(std::iter::repeat_n(b' ', indent * policy.indent_width));
                 } else if let Some(prev) = last_lit {
-                    if needs_space_between(prev, value) {
+                    if needs_space_between(prev, value, last_was_in_operand_position) {
                         bytes.extend_from_slice(separator);
                     }
                 }
                 bytes.extend_from_slice(value.as_bytes());
                 at_line_start = false;
+                last_was_in_operand_position = expecting_operand;
+                expecting_operand = leaves_operand_position(value);
                 last_lit = Some(value.as_str());
             }
         }
@@ -1871,7 +1883,32 @@ fn layout(tokens: &[Token], policy: &FormatPolicy) -> Vec<u8> {
     bytes
 }
 
-fn needs_space_between(last: &str, next: &str) -> bool {
+/// True iff emitting `tok` leaves the cursor in a position where the
+/// grammar expects an operand next. Operand-introducing tokens are open
+/// punctuation, separators, and operator-like strings; operand-terminating
+/// tokens are identifiers, literals, and closing punctuation.
+fn leaves_operand_position(tok: &str) -> bool {
+    if tok.is_empty() {
+        return true;
+    }
+    if is_punct_open(tok) {
+        return true;
+    }
+    if matches!(tok, "," | ";") {
+        return true;
+    }
+    if is_punct_close(tok) {
+        return false;
+    }
+    if first_is_alnum_or_underscore(tok) || last_ends_with_alnum(tok) {
+        return false;
+    }
+    // Pure punctuation/operator runs (`=`, `+`, `-`, `<=`, `>>`, …) leave
+    // the cursor expecting another operand.
+    true
+}
+
+fn needs_space_between(last: &str, next: &str, expecting_operand: bool) -> bool {
     if last.is_empty() || next.is_empty() {
         return false;
     }
@@ -1887,6 +1924,14 @@ fn needs_space_between(last: &str, next: &str) -> bool {
     if last == "." || next == "." {
         return false;
     }
+    // Tight unary prefix: `last` is a sign/logical-not operator emitted
+    // where the grammar expected an operand, so it glues to `next`.
+    // `expecting_operand` here means: just before `last` was emitted,
+    // the cursor expected an operand, which makes `last` a unary prefix.
+    // Examples: `f(-1.0)`, `[ -2, 3 ]`, `return -x`, `a = !flag`.
+    if expecting_operand && is_unary_prefix_operator(last) && first_is_operand_start(next) {
+        return false;
+    }
     if last_is_word_like(last) && first_is_word_like(next) {
         return true;
     }
@@ -1896,6 +1941,17 @@ fn needs_space_between(last: &str, next: &str) -> bool {
     // Adjacent operator runs: keep them apart so the lexer doesn't glue
     // `>` and `=` into `>=` unintentionally.
     true
+}
+
+fn is_unary_prefix_operator(s: &str) -> bool {
+    matches!(s, "-" | "+" | "!" | "~")
+}
+
+fn first_is_operand_start(s: &str) -> bool {
+    s.chars()
+        .next()
+        .map(|c| c.is_alphanumeric() || c == '_' || c == '.' || c == '(')
+        .unwrap_or(false)
 }
 
 fn is_punct_open(s: &str) -> bool {

--- a/crates/panproto-parse/tests/emit_pretty_signed_number.rs
+++ b/crates/panproto-parse/tests/emit_pretty_signed_number.rs
@@ -1,0 +1,48 @@
+//! Regression: `emit_pretty` does not insert whitespace inside a
+//! `signed_number` (or any other tight unary-prefix) production.
+//!
+//! Pre-fix, `f(-1.0)` rendered as `f(- 1.0)` because the layout pass
+//! treated `-` and `1.0` as adjacent operator-run-then-operand tokens
+//! and inserted the default separator between them. The result parsed
+//! as a different AST: unary-minus applied to a positive literal,
+//! rather than a single negative literal.
+//!
+//! The fix tracks an `expecting_operand` flag through the layout pass.
+//! When the previous token was emitted while the cursor expected an
+//! operand (start of stream / line, after `(` / `[` / `{` / `,` / `;`,
+//! or after another binary or assignment operator), and that previous
+//! token is `-` / `+` / `!` / `~`, it is treated as a tight unary
+//! prefix and glued to the following operand.
+
+#![cfg(all(feature = "grammars", feature = "lang-qvr"))]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use panproto_parse::ParserRegistry;
+
+const QVR_NEGATIVE_ARG: &[u8] = b"\
+program p : X -> X:
+    sample a <- f(-1.0)
+    return a
+";
+
+#[test]
+fn emit_pretty_keeps_signed_number_tight_inside_call() {
+    let reg = ParserRegistry::new();
+    let schema = reg
+        .parse_with_protocol("qvr", QVR_NEGATIVE_ARG, "neg.qvr")
+        .expect("parse");
+
+    let bytes = reg
+        .emit_pretty_with_protocol("qvr", &schema)
+        .expect("emit_pretty");
+    let text = String::from_utf8(bytes).expect("utf8");
+
+    assert!(
+        text.contains("-1.0") || text.contains("-1."),
+        "rendered output split the signed literal: {text:?}"
+    );
+    assert!(
+        !text.contains("- 1.0"),
+        "whitespace inserted between '-' and '1.0' (pre-fix bug): {text:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- `emit_pretty`'s layout pass inserted a space between `-` / `+` / `!` / `~` and the next token. `f(-1.0)` became `f(- 1.0)`, which parses as a different AST (unary-minus applied to a positive literal).
- Layout now tracks an `expecting_operand` flag along the token stream. When the previous token was emitted in operand position (start of stream / line, after open punctuation, after `,` / `;`, after another operator-run) and is `-` / `+` / `!` / `~`, it is recognised as a tight unary prefix and glues to the following operand. Binary `a - b` keeps spaces because the cursor was not in operand position when `-` was emitted.
- Bump workspace to 0.48.6. Stacked on #118 (grammars default-feature leak).

Closes #111.

## Test plan
- [x] Regression test at `crates/panproto-parse/tests/emit_pretty_signed_number.rs`.
- [x] All 52 panproto-parse tests pass under `--features grammars,lang-qvr`.
- [ ] CI: clippy, nextest, fmt, version consistency.