### PR TITLE
fix(parse): recognise named-ALIAS children in emit_pretty CHOICE dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.48.7] - 2026-05-21
+
+### Fixed
+
+- **`emit_pretty` recognises named-ALIAS children when picking CHOICE alternatives** (`panproto-parse::emit_pretty`): `referenced_symbols` previously walked into an `ALIAS { content, value, named }` production's content and discarded the alias `value`. A named ALIAS introduces a child vertex whose kind is the alias `value` (e.g. lilypond's `ALIAS { content: STRING "=", value: "punctuation", named: true }` introduces a `punctuation` child), but cursor-driven dispatch matched alts only on the inner SYMBOLs. The lilypond `named_context` rule's third arm (`SEQ(ALIAS_punctuation, CHOICE(symbol, string))`) was invisible to dispatch, so `\new Voice = "kick" { ... }` dropped the `=` punctuation and `"kick"` string in `emit_pretty`, losing the voice label. `referenced_symbols` now yields the alias `value` for named aliases, so dispatch can resolve the alt that produces a named-aliased child kind. Regression test at `crates/panproto-parse/tests/emit_pretty_lilypond_alias.rs`. Partially closes #113 (lilypond piece).
+
 ## [0.48.6] - 2026-05-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.6"
+version = "0.48.7"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.48.6", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.48.6", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.48.6", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.48.6", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.48.6", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.48.6", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.48.6", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.48.6", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.48.6", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.48.6", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.48.6", path = "crates/panproto-core" }
-panproto-io = { version = "0.48.6", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.48.6", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.48.6", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.48.6", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.48.6", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.48.6", path = "crates/panproto-parse" }
-panproto-project = { version = "0.48.6", path = "crates/panproto-project" }
-panproto-git = { version = "0.48.6", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.48.6", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.48.6", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.48.6", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.48.6", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.48.7", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.48.7", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.48.7", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.48.7", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.48.7", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.48.7", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.48.7", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.48.7", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.48.7", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.48.7", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.48.7", path = "crates/panproto-core" }
+panproto-io = { version = "0.48.7", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.48.7", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.48.7", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.48.7", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.48.7", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.48.7", path = "crates/panproto-parse" }
+panproto-project = { version = "0.48.7", path = "crates/panproto-project" }
+panproto-git = { version = "0.48.7", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.48.7", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.48.7", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.48.7", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.48.7", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.48.6
+version:            0.48.7
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.48.6",
+  "version": "0.48.7",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.6", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/src/emit_pretty.rs
+++ b/crates/panproto-parse/src/emit_pretty.rs
@@ -1523,11 +1523,28 @@ fn referenced_symbols(production: &Production) -> Vec<&str> {
                     walk(m, out);
                 }
             }
+            Production::Alias {
+                content,
+                named,
+                value,
+            } => {
+                // A named ALIAS produces a child vertex whose kind is
+                // the alias `value` (e.g. `ALIAS { content: STRING "=",
+                // value: "punctuation", named: true }` introduces a
+                // `punctuation` child). For cursor-driven dispatch to
+                // recognise alts that emit such children, yield the
+                // alias value as a referenced symbol. Anonymous aliases
+                // do not introduce a named node and only need their
+                // inner content's symbols.
+                if *named && !value.is_empty() {
+                    out.push(value.as_str());
+                }
+                walk(content, out);
+            }
             Production::Repeat { content }
             | Production::Repeat1 { content }
             | Production::Optional { content }
             | Production::Field { content, .. }
-            | Production::Alias { content, .. }
             | Production::Token { content }
             | Production::ImmediateToken { content }
             | Production::Prec { content, .. }

--- a/crates/panproto-parse/tests/emit_pretty_lilypond_alias.rs
+++ b/crates/panproto-parse/tests/emit_pretty_lilypond_alias.rs
@@ -1,0 +1,50 @@
+//! Regression: `emit_pretty` includes children produced by named
+//! `ALIAS { content: STRING, value: K, named: true }` productions when
+//! picking a CHOICE alternative.
+//!
+//! Pre-fix, `referenced_symbols` walked into an `ALIAS`'s content and
+//! ignored the alias `value`. Cursor-driven dispatch then matched
+//! alternatives only on inner SYMBOLs, so the lilypond `named_context`
+//! third CHOICE arm (`SEQ(ALIAS_punctuation, CHOICE(symbol, string))`,
+//! introducing `punctuation` and `string` children) was invisible: the
+//! emitter fell through to the BLANK alternative and dropped both
+//! children. `\new Voice = "kick"` rendered as `\new Voice`, losing the
+//! voice label entirely.
+//!
+//! The fix yields the alias `value` from `referenced_symbols` when the
+//! alias is named, so cursor-driven dispatch can recognise the alt that
+//! introduces a `punctuation` child.
+
+#![cfg(all(feature = "grammars", feature = "lang-lilypond"))]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use panproto_parse::ParserRegistry;
+
+const LILY_NAMED_CONTEXT: &[u8] =
+    b"\\version \"2.24.0\"\n\\new Voice = \"kick\" { c,4 r4 }\n";
+
+#[test]
+fn emit_pretty_preserves_named_context_punctuation_and_string() {
+    let reg = ParserRegistry::new();
+    let schema = reg
+        .parse_with_protocol("lilypond", LILY_NAMED_CONTEXT, "audit.ly")
+        .expect("parse");
+
+    let bytes = reg
+        .emit_pretty_with_protocol("lilypond", &schema)
+        .expect("emit_pretty");
+    let text = String::from_utf8(bytes).expect("utf8");
+
+    assert!(
+        text.contains('='),
+        "named_context `=` punctuation dropped from {text:?}"
+    );
+    assert!(
+        text.contains("kick"),
+        "named_context `string` child dropped from {text:?}"
+    );
+    assert!(
+        text.contains("Voice"),
+        "named_context `symbol` child dropped from {text:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- `referenced_symbols` walked into an `ALIAS { content, value, named }` production's content and discarded the alias `value`. A named ALIAS introduces a child vertex whose kind is the alias `value`, but cursor-driven dispatch matched alts only on inner SYMBOLs. The lilypond `named_context` third CHOICE arm was invisible, so `\new Voice = "kick" { ... }` dropped `=` and `"kick"`, losing the voice label.
- `referenced_symbols` now yields the alias `value` for named aliases.
- Bump workspace to 0.48.7. Stacked on #119 (signed-number).

Partially closes #113 (lilypond piece).

## Test plan
- [x] Regression test at `crates/panproto-parse/tests/emit_pretty_lilypond_alias.rs`.
- [x] All 49 panproto-parse tests pass under `--features grammars,lang-lilypond`.
- [ ] CI: clippy, nextest, fmt, version consistency.