### PR TITLE
fix(parse): render newline-shaped PATTERN as a line break in emit_pretty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.48.8] - 2026-05-21
+
+### Fixed
+
+- **`emit_pretty` renders newline-shaped PATTERN terminals as newlines, not the bare `_` placeholder** (`panproto-parse::emit_pretty`): csound's `_new_line` is `TOKEN(PATTERN "\r?\n")`. The pattern fell through `placeholder_for_pattern`'s final `else` arm (no `[0-9]` / `[a-zA-Z_]` / `"` / `'` markers) and returned the bare `"_"` sentinel. csound's `instrument_definition` SEQ has a REPEAT of `_statement` requiring `_new_line` between siblings, so the placeholder injected unparseable `_` characters between every pair of structural siblings (`endin _ </CsInstruments> _ </CsoundSynthesizer>`). The PATTERN handler now recognises `\r?\n`-shaped patterns and routes them through `Output::newline()` (`Token::LineBreak`), and recognises generic whitespace patterns (`\s+`, `[ \t]+`, ` *`) and drops them so the layout pass's policy separator inserts the actual spacing. Other patterns still fall through to the heuristic placeholder. Regression test at `crates/panproto-parse/tests/emit_pretty_csound_newline.rs`. Partially closes #113 (csound piece).
+
 ## [0.48.7] - 2026-05-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.7"
+version = "0.48.8"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.48.7", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.48.7", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.48.7", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.48.7", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.48.7", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.48.7", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.48.7", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.48.7", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.48.7", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.48.7", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.48.7", path = "crates/panproto-core" }
-panproto-io = { version = "0.48.7", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.48.7", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.48.7", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.48.7", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.48.7", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.48.7", path = "crates/panproto-parse" }
-panproto-project = { version = "0.48.7", path = "crates/panproto-project" }
-panproto-git = { version = "0.48.7", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.48.7", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.48.7", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.48.7", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.48.7", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.48.8", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.48.8", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.48.8", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.48.8", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.48.8", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.48.8", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.48.8", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.48.8", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.48.8", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.48.8", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.48.8", path = "crates/panproto-core" }
+panproto-io = { version = "0.48.8", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.48.8", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.48.8", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.48.8", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.48.8", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.48.8", path = "crates/panproto-parse" }
+panproto-project = { version = "0.48.8", path = "crates/panproto-project" }
+panproto-git = { version = "0.48.8", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.48.8", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.48.8", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.48.8", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.48.8", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.48.7
+version:            0.48.8
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.48.7",
+  "version": "0.48.8",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.7", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/src/emit_pretty.rs
+++ b/crates/panproto-parse/src/emit_pretty.rs
@@ -868,6 +868,19 @@ fn emit_production_inner(
         Production::Pattern { value } => {
             if let Some(literal) = literal_value(schema, vertex_id) {
                 out.token(literal);
+            } else if is_newline_like_pattern(value) {
+                // Patterns like `\r?\n`, `\n`, `\r\n` are the structural
+                // newline tokens grammars use to separate top-level
+                // statements (csound's `_new_line`, ABC's line-end, etc.).
+                // Emitting them through the placeholder fallback rendered
+                // the bare `_` sentinel between siblings; route them to
+                // the layout pass's line-break instead so the output
+                // re-parses.
+                out.newline();
+            } else if is_whitespace_only_pattern(value) {
+                // `\s+`, `[ \t]+` and friends are interstitial whitespace
+                // tokens. Emit nothing: the layout pass inserts the
+                // policy separator between adjacent Lits if needed.
             } else {
                 out.token(&placeholder_for_pattern(value));
             }
@@ -1683,6 +1696,67 @@ fn literal_value<'a>(schema: &'a Schema, vertex_id: &panproto_gat::Name) -> Opti
         .iter()
         .find(|c| c.sort.as_ref() == "literal-value")
         .map(|c| c.value.as_str())
+}
+
+/// True iff `pattern` matches a (possibly optional / repeated) sequence
+/// of carriage-return and newline characters only. Examples: `\r?\n`,
+/// `\n`, `\r\n`, `\n+`, `\r?\n+`. Distinguishes structural newline
+/// terminals from generic whitespace and from other patterns that
+/// happen to contain a newline escape inside a larger class.
+fn is_newline_like_pattern(pattern: &str) -> bool {
+    if pattern.is_empty() {
+        return false;
+    }
+    let mut chars = pattern.chars().peekable();
+    let mut saw_newline_atom = false;
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => match chars.next() {
+                Some('n' | 'r') => saw_newline_atom = true,
+                _ => return false,
+            },
+            '?' | '*' | '+' => {} // quantifiers on the previous atom
+            _ => return false,
+        }
+    }
+    saw_newline_atom
+}
+
+/// True iff `pattern` matches a (possibly quantified) run of generic
+/// whitespace characters: `\s+`, `[ \t]+`, ` +`, `\s*`. Such patterns
+/// describe interstitial spacing rather than syntactic content, so the
+/// pretty emitter can drop them and let the layout pass insert the
+/// configured separator.
+fn is_whitespace_only_pattern(pattern: &str) -> bool {
+    if pattern.is_empty() {
+        return false;
+    }
+    // Strip an outer quantifier suffix.
+    let trimmed = pattern.trim_end_matches(['?', '*', '+']);
+    if trimmed.is_empty() {
+        return false;
+    }
+    // Bare `\s` / ` ` / `\t`.
+    if matches!(trimmed, "\\s" | " " | "\\t") {
+        return true;
+    }
+    // Character class containing only whitespace atoms.
+    if let Some(inner) = trimmed.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+        let mut chars = inner.chars().peekable();
+        let mut saw_atom = false;
+        while let Some(c) = chars.next() {
+            match c {
+                '\\' => match chars.next() {
+                    Some('s' | 't' | 'r' | 'n') => saw_atom = true,
+                    _ => return false,
+                },
+                ' ' | '\t' => saw_atom = true,
+                _ => return false,
+            }
+        }
+        return saw_atom;
+    }
+    false
 }
 
 fn placeholder_for_pattern(pattern: &str) -> String {

--- a/crates/panproto-parse/tests/emit_pretty_csound_newline.rs
+++ b/crates/panproto-parse/tests/emit_pretty_csound_newline.rs
@@ -1,0 +1,59 @@
+//! Regression: `emit_pretty` renders newline-shaped PATTERN terminals
+//! as newlines rather than the bare `_` placeholder.
+//!
+//! csound's `_new_line` is `TOKEN(PATTERN "\r?\n")`. Pre-fix, the
+//! pattern fell through `placeholder_for_pattern`'s final `else` arm
+//! (no `[0-9]` / `[a-zA-Z_]` / `"` / `'` markers) and returned the bare
+//! `"_"` sentinel. csound's `instrument_definition` SEQ includes a
+//! REPEAT of `_statement`, each of which expects a `_new_line` between
+//! statements; the placeholder dropped `_` characters between every
+//! pair of structural siblings, producing unparseable output like
+//! `endin _ </CsInstruments> _ </CsoundSynthesizer>`.
+//!
+//! The PATTERN handler now recognises `\r?\n`-shaped patterns and
+//! emits them through `Output::newline()` (`Token::LineBreak`), and
+//! recognises generic whitespace patterns (`\s+`, `[ \t]+`) and drops
+//! them so the layout pass's policy separator inserts the actual
+//! spacing. Anything else still falls through to the heuristic
+//! placeholder.
+
+#![cfg(all(feature = "grammars", feature = "lang-csound"))]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use panproto_parse::ParserRegistry;
+
+const CSOUND_SRC: &[u8] = b"\
+<CsoundSynthesizer>
+<CsInstruments>
+instr 1
+out 0.5 * oscili(0.5, 440, 1)
+endin
+</CsInstruments>
+</CsoundSynthesizer>
+";
+
+#[test]
+fn emit_pretty_csound_does_not_emit_underscore_placeholder_for_newline() {
+    let reg = ParserRegistry::new();
+    let schema = reg
+        .parse_with_protocol("csound", CSOUND_SRC, "audit.csd")
+        .expect("parse");
+
+    let bytes = reg
+        .emit_pretty_with_protocol("csound", &schema)
+        .expect("emit_pretty");
+    let text = String::from_utf8(bytes).expect("utf8");
+
+    assert!(
+        !text.contains(" _ ") && !text.contains("\n_\n"),
+        "newline-shaped PATTERN emitted as `_` placeholder: {text:?}"
+    );
+    assert!(
+        text.contains("endin"),
+        "instrument body lost endin keyword: {text:?}"
+    );
+    assert!(
+        text.contains("</CsoundSynthesizer>"),
+        "structural closer dropped: {text:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- csound's `_new_line` is `TOKEN(PATTERN \"\\r?\\n\")`. The pattern fell through `placeholder_for_pattern`'s final `else` (no `[0-9]` / `[a-zA-Z_]` / `\"` / `'` markers) and returned the bare `\"_\"` sentinel. Result: unparseable `\` _ \`` characters between every pair of structural siblings.
- PATTERN handler now recognises `\\r?\\n`-shaped patterns and routes them through `Output::newline()` (`Token::LineBreak`). Whitespace-only patterns (`\\s+`, `[ \\t]+`) are dropped and the layout pass's policy separator handles spacing.
- Bump workspace to 0.48.8. Stacked on #120.

Partially closes #113 (csound piece).

## Test plan
- [x] Regression test at `crates/panproto-parse/tests/emit_pretty_csound_newline.rs`.
- [x] All 47 panproto-parse tests pass under `--features grammars,lang-csound`.
- [ ] CI: clippy, nextest, fmt, version consistency.