### PR TITLE
fix(parse): drain tree-sitter extras as a side channel in emit_pretty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.48.9] - 2026-05-21
+
+### Fixed
+
+- **`emit_pretty` drains tree-sitter `extras` children as a side channel** (`panproto-parse::emit_pretty`): extras (typically `line_comment` / `block_comment`) live outside the production grammar — tree-sitter skips them at parse time and records them as children of the surrounding vertex — but the rule walker had no way to reconcile them against the cursor. Cursor-driven CHOICE dispatch returned `None` for an extras-kind child and the surrounding `REPEAT` loop terminated after zero iterations with no progress, producing **empty output** for supercollider's `source_file` (and any other grammar whose top-level rule's REPEAT body was reached with a leading comment). `Grammar` now records the set of named-symbol / aliased extras kinds; `emit_production` drains leading extras edges from the cursor at every entry, and `emit_vertex` drains trailing extras after the rule walk completes. Each drained extra is emitted via `emit_vertex`, preserving its content. Regression test at `crates/panproto-parse/tests/emit_pretty_extras.rs` parses a supercollider source with a leading `//` comment and asserts both the comment and the `Pdef` / `Pbind` calls survive. Partially closes #113 (supercollider piece).
+
 ## [0.48.8] - 2026-05-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.8"
+version = "0.48.9"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.48.8", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.48.8", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.48.8", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.48.8", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.48.8", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.48.8", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.48.8", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.48.8", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.48.8", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.48.8", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.48.8", path = "crates/panproto-core" }
-panproto-io = { version = "0.48.8", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.48.8", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.48.8", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.48.8", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.48.8", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.48.8", path = "crates/panproto-parse" }
-panproto-project = { version = "0.48.8", path = "crates/panproto-project" }
-panproto-git = { version = "0.48.8", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.48.8", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.48.8", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.48.8", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.48.8", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.48.9", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.48.9", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.48.9", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.48.9", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.48.9", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.48.9", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.48.9", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.48.9", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.48.9", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.48.9", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.48.9", path = "crates/panproto-core" }
+panproto-io = { version = "0.48.9", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.48.9", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.48.9", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.48.9", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.48.9", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.48.9", path = "crates/panproto-parse" }
+panproto-project = { version = "0.48.9", path = "crates/panproto-project" }
+panproto-git = { version = "0.48.9", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.48.9", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.48.9", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.48.9", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.48.9", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.48.8
+version:            0.48.9
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.48.8",
+  "version": "0.48.9",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.8", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/src/emit_pretty.rs
+++ b/crates/panproto-parse/src/emit_pretty.rs
@@ -273,6 +273,19 @@ pub struct Grammar {
     /// supertype name when a SYMBOL references it.
     #[serde(default, deserialize_with = "deserialize_supertypes")]
     pub supertypes: std::collections::HashSet<String>,
+    /// Tree-sitter `extras` rules: the named symbols (typically comments)
+    /// that tree-sitter skips at parse time but records as children of the
+    /// surrounding vertex. They appear nowhere in the production grammar,
+    /// so the rule walker cannot reconcile them against the cursor — the
+    /// emit pass therefore drains them as a side channel: at vertex entry
+    /// and between REPEAT iterations any leading extras-kind edges are
+    /// consumed and emitted directly. The set is populated at
+    /// `Grammar::from_bytes` by collecting every `SYMBOL { name }` and
+    /// named `ALIAS { value, named: true }` under the top-level `extras`
+    /// array. Pattern-only extras (e.g. `\s` whitespace) are not vertex
+    /// kinds and are excluded.
+    #[serde(default, deserialize_with = "deserialize_extras")]
+    pub extras: std::collections::HashSet<String>,
     /// Precomputed subtyping closure: `subtypes[symbol_name]` is the
     /// set of vertex kinds that satisfy a SYMBOL `symbol_name`
     /// reference on the schema side.
@@ -309,6 +322,48 @@ where
                 }
             }
             _ => {}
+        }
+    }
+    Ok(out)
+}
+
+fn deserialize_extras<'de, D>(
+    deserializer: D,
+) -> Result<std::collections::HashSet<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let entries: Vec<serde_json::Value> = Vec::deserialize(deserializer)?;
+    let mut out = std::collections::HashSet::new();
+    for entry in entries {
+        if let serde_json::Value::Object(map) = entry {
+            let ty = map.get("type").and_then(serde_json::Value::as_str);
+            match ty {
+                // SYMBOL { name: K } — the extras rule is a named symbol
+                // (typically `line_comment` / `block_comment`). The kind
+                // K appears as a real child vertex on the schema side.
+                Some("SYMBOL") => {
+                    if let Some(serde_json::Value::String(name)) = map.get("name") {
+                        out.insert(name.clone());
+                    }
+                }
+                // ALIAS { content, value: V, named: true } — the extras
+                // rule renames its content; V is the kind on the schema.
+                Some("ALIAS") => {
+                    let named = map
+                        .get("named")
+                        .and_then(serde_json::Value::as_bool)
+                        .unwrap_or(false);
+                    if named {
+                        if let Some(serde_json::Value::String(value)) = map.get("value") {
+                            out.insert(value.clone());
+                        }
+                    }
+                }
+                // PATTERN / STRING / TOKEN entries describe inter-token
+                // whitespace and have no vertex-side representation.
+                _ => {}
+            }
         }
     }
     Ok(out)
@@ -667,7 +722,12 @@ fn emit_vertex(
     let edges = children_for(schema, vertex_id);
     if let Some(rule) = grammar.rules.get(kind) {
         let mut cursor = ChildCursor::new(&edges);
-        return emit_production(protocol, schema, grammar, vertex_id, rule, &mut cursor, out);
+        emit_production(protocol, schema, grammar, vertex_id, rule, &mut cursor, out)?;
+        // Drain any extras left after the rule walk completed; tree-sitter
+        // may record trailing comments as children of the surrounding
+        // vertex (i.e. after the last structural child the rule matched).
+        drain_extras(protocol, schema, grammar, &mut cursor, out)?;
+        return Ok(());
     }
 
     // No rule for this kind. The parser produced it via an ALIAS
@@ -844,11 +904,52 @@ fn emit_production(
             ),
         });
     }
+    drain_extras(protocol, schema, grammar, cursor, out)?;
     let result = emit_production_inner(
         protocol, schema, grammar, vertex_id, production, cursor, out,
     );
     EMIT_DEPTH.with(|d| d.set(d.get() - 1));
     result
+}
+
+/// Consume and emit every leading edge on `cursor` whose target kind
+/// is in `grammar.extras` (typically `line_comment` / `block_comment`).
+/// Extras live outside the production grammar — tree-sitter skips them
+/// at parse time and records them as children of the surrounding
+/// vertex — so the rule walker cannot reconcile them against the
+/// cursor. Draining them as a side channel preserves their content in
+/// the output without confusing the structural matchers.
+fn drain_extras(
+    protocol: &str,
+    schema: &Schema,
+    grammar: &Grammar,
+    cursor: &mut ChildCursor<'_>,
+    out: &mut Output<'_>,
+) -> Result<(), ParseError> {
+    if grammar.extras.is_empty() {
+        return Ok(());
+    }
+    loop {
+        let next_extra: Option<usize> = cursor
+            .edges
+            .iter()
+            .enumerate()
+            .find(|(i, _)| !cursor.consumed[*i])
+            .and_then(|(i, edge)| {
+                let kind = schema.vertices.get(&edge.tgt).map(|v| v.kind.as_ref())?;
+                if grammar.extras.contains(kind) {
+                    Some(i)
+                } else {
+                    None
+                }
+            });
+        let Some(idx) = next_extra else {
+            return Ok(());
+        };
+        cursor.consumed[idx] = true;
+        let target = &cursor.edges[idx].tgt;
+        emit_vertex(protocol, schema, grammar, target, out)?;
+    }
 }
 
 fn emit_production_inner(

--- a/crates/panproto-parse/tests/emit_pretty_extras.rs
+++ b/crates/panproto-parse/tests/emit_pretty_extras.rs
@@ -1,0 +1,52 @@
+//! Regression: `emit_pretty` drains tree-sitter `extras` children
+//! (typically `line_comment` / `block_comment`) as a side channel,
+//! rather than letting them suppress emission of every structural
+//! sibling.
+//!
+//! Pre-fix, extras like supercollider's `line_comment` were recorded
+//! as children of the surrounding vertex but were not referenced
+//! anywhere in the production grammar. Cursor-driven CHOICE dispatch
+//! found no alternative whose body could satisfy a `line_comment`
+//! child kind, returned `None`, and the surrounding `REPEAT` loop
+//! terminated after one iteration with `consumed == 0`. The result on
+//! supercollider was an empty byte output for any non-trivial source.
+//!
+//! `Grammar::extras` now records the set of named-symbol / aliased
+//! kinds declared under the grammar's `extras` array. `emit_production`
+//! drains leading extras-kind edges from the cursor at every entry,
+//! and `emit_vertex` drains trailing extras after the rule walk
+//! completes. Each drained extra is emitted via `emit_vertex` to
+//! preserve its content.
+
+#![cfg(all(feature = "grammars", feature = "lang-supercollider"))]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use panproto_parse::ParserRegistry;
+
+const SUPERCOLLIDER_SRC: &[u8] = b"// hello\nPdef(\\kick, Pbind(\\bus, \\drums, \\dur, 0.25));\n";
+
+#[test]
+fn emit_pretty_supercollider_preserves_comment_and_structural_siblings() {
+    let reg = ParserRegistry::new();
+    let schema = reg
+        .parse_with_protocol("supercollider", SUPERCOLLIDER_SRC, "audit.scd")
+        .expect("parse");
+
+    let bytes = reg
+        .emit_pretty_with_protocol("supercollider", &schema)
+        .expect("emit_pretty");
+    let text = String::from_utf8(bytes).expect("utf8");
+
+    assert!(
+        !text.is_empty(),
+        "emit_pretty returned an empty byte string (pre-fix regression)"
+    );
+    assert!(
+        text.contains("Pdef") && text.contains("Pbind"),
+        "structural function calls missing from output: {text:?}"
+    );
+    assert!(
+        text.contains("// hello"),
+        "leading extras (line_comment) dropped from output: {text:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Extras (line_comment / block_comment) live outside the production grammar; tree-sitter skips them at parse time but records them as children of the surrounding vertex. The rule walker had no way to match them, so a leading comment on supercollider's `source_file` caused cursor-driven CHOICE dispatch to return None, REPEAT to terminate at zero, and the whole output to be empty.
- `Grammar` now records the named-symbol / aliased extras kinds. `emit_production` drains leading extras at every entry; `emit_vertex` drains trailing extras after the rule walk completes. Each extra is emitted through `emit_vertex` so its content survives.
- Bump workspace to 0.48.9. Stacked on #121.

Partially closes #113 (supercollider piece).

## Test plan
- [x] Regression test at `crates/panproto-parse/tests/emit_pretty_extras.rs`.
- [x] All 56 panproto-parse tests pass under `--features grammars,lang-supercollider,lang-lilypond,lang-csound,lang-qvr`.
- [ ] CI: clippy, nextest, fmt, version consistency.