### PR TITLE
fix(parse): route newline grammar STRINGs through LineBreak channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.48.10] - 2026-05-21
+
+### Fixed
+
+- **`emit_pretty` routes newline-valued grammar STRINGs through the layout `LineBreak` channel** (`panproto-parse::emit_pretty`): `Output::token` pushed every grammar STRING as a `Lit`. A `STRING "\n"` literal (abc's `_NL`, plus every grammar that uses a literal newline as a statement terminator) left the newline character in the output but the layout pass's `needs_space_between` then inserted the configured separator between the newline `Lit` and the following token, producing leading spaces on every line after the first and trailing spaces before every newline. `Output::token` now recognises `"\n"` / `"\r"` / `"\r\n"` and pushes `Token::LineBreak` directly so layout treats it as a line-state reset rather than a normal Lit pair. Regression test at `crates/panproto-parse/tests/emit_pretty_newline_string.rs` parses an abc header and asserts no trailing space precedes any newline. Partially closes #113 (abc whitespace piece).
+
 ## [0.48.9] - 2026-05-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.9"
+version = "0.48.10"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.48.9", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.48.9", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.48.9", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.48.9", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.48.9", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.48.9", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.48.9", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.48.9", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.48.9", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.48.9", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.48.9", path = "crates/panproto-core" }
-panproto-io = { version = "0.48.9", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.48.9", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.48.9", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.48.9", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.48.9", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.48.9", path = "crates/panproto-parse" }
-panproto-project = { version = "0.48.9", path = "crates/panproto-project" }
-panproto-git = { version = "0.48.9", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.48.9", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.48.9", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.48.9", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.48.9", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.48.10", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.48.10", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.48.10", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.48.10", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.48.10", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.48.10", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.48.10", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.48.10", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.48.10", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.48.10", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.48.10", path = "crates/panproto-core" }
+panproto-io = { version = "0.48.10", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.48.10", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.48.10", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.48.10", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.48.10", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.48.10", path = "crates/panproto-parse" }
+panproto-project = { version = "0.48.10", path = "crates/panproto-project" }
+panproto-git = { version = "0.48.10", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.48.10", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.48.10", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.48.10", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.48.10", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.48.9
+version:            0.48.10
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.48.9",
+  "version": "0.48.10",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.9", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/src/emit_pretty.rs
+++ b/crates/panproto-parse/src/emit_pretty.rs
@@ -1966,6 +1966,18 @@ impl<'a> Output<'a> {
             return;
         }
 
+        // A grammar STRING whose value is a newline (e.g. abc's `_NL = "\n"`
+        // or any rule that uses `"\n"` as a structural line terminator)
+        // must route through the layout's `LineBreak` channel. Emitting it
+        // as a `Lit` leaves the newline character in the byte stream but
+        // also makes `needs_space_between` insert the configured separator
+        // between the newline and the following token, producing leading
+        // spaces on every line after the first.
+        if value == "\n" || value == "\r\n" || value == "\r" {
+            self.tokens.push(Token::LineBreak);
+            return;
+        }
+
         if self.policy.indent_close.iter().any(|t| t == value) {
             self.tokens.push(Token::IndentClose);
         }

--- a/crates/panproto-parse/tests/emit_pretty_newline_string.rs
+++ b/crates/panproto-parse/tests/emit_pretty_newline_string.rs
@@ -1,0 +1,59 @@
+//! Regression: a grammar STRING whose value is a newline (e.g. abc's
+//! `_NL = STRING "\n"`) routes through the layout pass's `LineBreak`
+//! channel rather than through `Token::Lit`.
+//!
+//! Pre-fix, `Output::token` pushed every grammar STRING as a `Lit`. A
+//! literal `"\n"` STRING left the newline character in the output but
+//! the layout pass's `needs_space_between` then inserted the configured
+//! separator between the newline and the following token, producing
+//! leading spaces on every line after the first when the grammar used
+//! `STRING "\n"` as a line terminator (abc's `_NL`, csound's
+//! line-terminator alts, and any grammar with a similar shape). The
+//! same path also produced trailing spaces before every newline
+//! because the separator landed between the line's last content token
+//! and the following `"\n"` Lit.
+//!
+//! `Output::token` now recognises `"\n"` / `"\r"` / `"\r\n"` and pushes
+//! `Token::LineBreak` directly. The layout pass treats LineBreak as a
+//! line-state reset, so neither leading nor trailing separators slip
+//! in around the structural line break.
+
+#![cfg(all(feature = "grammars", feature = "lang-abc"))]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use panproto_parse::ParserRegistry;
+
+const ABC_HEADER_SRC: &[u8] = b"X:1\nT:Test\nM:4/4\nL:1/8\nK:C\nCDEF GABc|\n";
+
+#[test]
+fn emit_pretty_abc_does_not_leak_whitespace_around_string_newline() {
+    let reg = ParserRegistry::new();
+    let schema = reg
+        .parse_with_protocol("abc", ABC_HEADER_SRC, "audit.abc")
+        .expect("parse");
+
+    let bytes = reg
+        .emit_pretty_with_protocol("abc", &schema)
+        .expect("emit_pretty");
+    let text = String::from_utf8(bytes).expect("utf8");
+
+    // No trailing space before a newline. Pre-fix every header line
+    // ended with ` \n` because `needs_space_between(content, "\n")`
+    // returned true.
+    for line in text.lines() {
+        assert!(
+            !line.ends_with(' '),
+            "trailing space before newline survived: {line:?} in {text:?}"
+        );
+    }
+
+    // Header keywords still emit. Pre-fix this would have passed
+    // (the bug was whitespace, not content), but it pins the keyword
+    // dispatch alongside the layout fix.
+    for keyword in ["X:", "M:", "L:", "K:"] {
+        assert!(
+            text.contains(keyword),
+            "header keyword {keyword:?} dropped from output: {text:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `Output::token` pushed every grammar STRING as a `Lit`. A `STRING \"\\n\"` literal (abc's `_NL`, plus every grammar that uses a literal newline as statement terminator) left the newline character in the byte stream, but the layout pass's `needs_space_between` then inserted the configured separator between the newline Lit and the following token. Result: leading space on every line after the first, and trailing space before every newline.
- `Output::token` now recognises `\"\\n\"` / `\"\\r\"` / `\"\\r\\n\"` and pushes `Token::LineBreak` directly. The layout pass treats LineBreak as a line-state reset.
- Bump workspace to 0.48.10. Stacked on #122.

Partially closes #113 (abc whitespace piece). Two known remaining abc bugs: a leading space on the first tune_header_info_line (parser-side interstitial leak), and space between adjacent note letters in a `beam` (`CDEF` → `C D E F`, needs grammar-aware tight-adjacency policy).

## Test plan
- [x] Regression test at `crates/panproto-parse/tests/emit_pretty_newline_string.rs` asserts no trailing space precedes any newline in the abc output.
- [x] All 58 panproto-parse tests pass under `--features grammars,lang-abc,lang-csound,lang-supercollider,lang-lilypond,lang-qvr`.
- [ ] CI: clippy, nextest, fmt, version consistency.