### PR TITLE
fix(jit): gate match default block on absence of irrefutable arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.48.11] - 2026-05-21
+
+### Fixed
+
+- **`panproto-jit` match codegen emits valid IR when arms include an irrefutable pattern** (`panproto-jit::codegen`): `compile_match` built the literal-arm `then` / `else` chain and then unconditionally emitted a fall-through default block. The wildcard / var-pattern handler at the same level already terminated its block with a branch to `merge_bb` and broke out of the loop, but the fall-through code ran anyway. It pushed a duplicate `(0, wildcard_block)` entry into the phi node and emitted a second unconditional branch on a basic block that already had a terminator. The IR was malformed and the phi resolved to the wildcard arm's value even when an earlier literal arm matched the scrutinee. `match 2 { 1 => 10, 2 => 20, _ => 0 }` returned `0` instead of `20`. The default block is now gated on whether any irrefutable arm has already terminated the cascade; when one has, the synthetic default is skipped entirely. Closes #115.
+
 ## [0.48.10] - 2026-05-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.10"
+version = "0.48.11"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.48.10", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.48.10", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.48.10", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.48.10", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.48.10", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.48.10", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.48.10", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.48.10", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.48.10", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.48.10", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.48.10", path = "crates/panproto-core" }
-panproto-io = { version = "0.48.10", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.48.10", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.48.10", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.48.10", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.48.10", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.48.10", path = "crates/panproto-parse" }
-panproto-project = { version = "0.48.10", path = "crates/panproto-project" }
-panproto-git = { version = "0.48.10", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.48.10", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.48.10", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.48.10", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.48.10", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.48.11", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.48.11", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.48.11", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.48.11", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.48.11", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.48.11", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.48.11", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.48.11", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.48.11", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.48.11", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.48.11", path = "crates/panproto-core" }
+panproto-io = { version = "0.48.11", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.48.11", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.48.11", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.48.11", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.48.11", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.48.11", path = "crates/panproto-parse" }
+panproto-project = { version = "0.48.11", path = "crates/panproto-project" }
+panproto-git = { version = "0.48.11", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.48.11", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.48.11", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.48.11", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.48.11", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.48.10
+version:            0.48.11
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.48.10",
+  "version": "0.48.11",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.10", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-jit/src/codegen.rs
+++ b/crates/panproto-jit/src/codegen.rs
@@ -437,6 +437,14 @@ mod inner {
             let i64_type = self.context.i64_type();
             let mut results: Vec<(BasicValueEnum<'ctx>, inkwell::basic_block::BasicBlock<'ctx>)> =
                 Vec::new();
+            // Tracks whether an irrefutable arm (Wildcard / Var) has
+            // already terminated the cascade. The synthetic fall-through
+            // default block at the end is only inserted when no
+            // irrefutable arm covered the residual case; otherwise the
+            // wildcard's branch has already terminated the chain and
+            // appending another (phi-edge, branch) pair on a block that
+            // already has a terminator produces malformed IR.
+            let mut saw_irrefutable_arm = false;
 
             for (i, (pattern, body)) in arms.iter().enumerate() {
                 match pattern {
@@ -456,7 +464,8 @@ mod inner {
                         builder
                             .build_unconditional_branch(merge_bb)
                             .map_err(Self::cg_err)?;
-                        break; // Wildcard is always last.
+                        saw_irrefutable_arm = true;
+                        break; // Wildcard / var is always last.
                     }
                     panproto_expr::Pattern::Lit(lit) => {
                         let lit_val = self.compile_literal(lit)?;
@@ -504,17 +513,27 @@ mod inner {
                 }
             }
 
-            // If we fell through all arms without matching, return 0.
-            let current_bb = builder
-                .get_insert_block()
-                .ok_or_else(|| JitError::CodegenFailed {
-                    reason: "no insert block".to_owned(),
-                })?;
-            let default_val = i64_type.const_int(0, false);
-            results.push((default_val.into(), current_bb));
-            builder
-                .build_unconditional_branch(merge_bb)
-                .map_err(Self::cg_err)?;
+            // Fall-through default: only emitted when no irrefutable arm
+            // terminated the cascade. Without this gate, a wildcard arm
+            // followed by the default block would push a duplicate phi
+            // edge into the same wildcard block and emit a second
+            // unconditional branch on a basic block that already has a
+            // terminator, leaving the IR malformed and the phi resolving
+            // to the wildcard's value instead of the matching literal
+            // arm's value.
+            if !saw_irrefutable_arm {
+                let current_bb =
+                    builder
+                        .get_insert_block()
+                        .ok_or_else(|| JitError::CodegenFailed {
+                            reason: "no insert block".to_owned(),
+                        })?;
+                let default_val = i64_type.const_int(0, false);
+                results.push((default_val.into(), current_bb));
+                builder
+                    .build_unconditional_branch(merge_bb)
+                    .map_err(Self::cg_err)?;
+            }
 
             // Build phi node in merge block.
             builder.position_at_end(merge_bb);


### PR DESCRIPTION
## Summary

- `compile_match` built the literal-arm cascade and then unconditionally emitted a fall-through default block at the end. The wildcard / var-pattern arm already terminated its block with a branch to `merge_bb` and broke out of the loop, but the fall-through code ran anyway and emitted a second unconditional branch on a basic block that already had a terminator, plus a duplicate phi edge.
- The default block is now gated on a `saw_irrefutable_arm` flag. When an irrefutable arm has terminated the cascade, the synthetic default is skipped, the phi has exactly one incoming edge per emitted arm, and the IR is well-formed.
- Bump workspace to 0.48.11. Stacked on #123.

Closes #115.

## Test plan
- [x] All 19 `panproto-jit` tests pass under `--features inkwell-jit`, including `jit_match_literal` which previously failed with `assertion left == right failed; left: 0, right: 20`.
- [ ] CI: clippy, nextest, fmt, version consistency.