### PR TITLE
fix(parse): tight emit_pretty between REPEAT iterations with empty separator slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.48.12] - 2026-05-21
+
+### Fixed
+
+- **`emit_pretty` keeps sibling REPEAT iterations tight when the separator slot is empty** (`panproto-parse::emit_pretty`): when a `REPEAT` / `REPEAT1` body is `SEQ(SEP, BODY)` and `SEP` is `CHOICE` containing `BLANK` (or an `OPTIONAL`), the categorical reading is that the source-level separator between two iterations is syntactically optional. When the runtime alternative chosen for the separator slot emits zero content tokens (BLANK picked), the source had no separator between this iteration and the previous one; the layout pass must not inject the policy separator either. Pre-fix, ABC's `beam` rule (`SEQ(_nte_or_chrd, REPEAT1(SEQ(CHOICE(BEAM_SEPARATOR, BLANK), _nte_or_chrd)))`) rendered consecutive note letters as `C D E F` (source was `CDEF`) because layout had no signal that the iteration boundary carried no source-level separator. The REPEAT walker now structurally recognises separator-leading SEQ bodies, emits the separator slot first while observing whether any content token was produced, and pushes a `Token::NoSpace` marker before the remaining SEQ members when the slot was empty. The layout pass consumes the marker and suppresses the inter-Lit separator for that pair. Bodies whose first SEQ member is not a `CHOICE`-with-`BLANK` / `OPTIONAL` (e.g. `commaSep1`'s `SEQ(STRING ",", SYMBOL)`) take the original code path unchanged. Regression test at `crates/panproto-parse/tests/emit_pretty_tight_repeat.rs`. Improves #113 (ABC beam piece).
+
 ## [0.48.11] - 2026-05-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.11"
+version = "0.48.12"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.48.11", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.48.11", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.48.11", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.48.11", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.48.11", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.48.11", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.48.11", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.48.11", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.48.11", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.48.11", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.48.11", path = "crates/panproto-core" }
-panproto-io = { version = "0.48.11", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.48.11", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.48.11", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.48.11", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.48.11", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.48.11", path = "crates/panproto-parse" }
-panproto-project = { version = "0.48.11", path = "crates/panproto-project" }
-panproto-git = { version = "0.48.11", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.48.11", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.48.11", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.48.11", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.48.11", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.48.12", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.48.12", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.48.12", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.48.12", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.48.12", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.48.12", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.48.12", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.48.12", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.48.12", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.48.12", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.48.12", path = "crates/panproto-core" }
+panproto-io = { version = "0.48.12", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.48.12", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.48.12", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.48.12", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.48.12", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.48.12", path = "crates/panproto-parse" }
+panproto-project = { version = "0.48.12", path = "crates/panproto-project" }
+panproto-git = { version = "0.48.12", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.48.12", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.48.12", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.48.12", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.48.12", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.48.11
+version:            0.48.12
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.48.11",
+  "version": "0.48.12",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.11", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/src/emit_pretty.rs
+++ b/crates/panproto-parse/src/emit_pretty.rs
@@ -1112,13 +1112,84 @@ fn emit_production_inner(
             }
         }
         Production::Repeat { content } | Production::Repeat1 { content } => {
+            // Detect a "separator-leading SEQ" iteration body: SEQ whose
+            // first member is a CHOICE containing BLANK (or an OPTIONAL),
+            // i.e. the source-level separator between two iterations is
+            // syntactically optional. When the chosen alternative for
+            // that separator slot emits zero content tokens at runtime,
+            // there was no source-level separator between this iteration
+            // and the previous one; the layout pass must suppress its
+            // policy separator to match the source's tight adjacency.
+            //
+            // Categorical reading: REPEAT body `B = SEQ(SEP, BODY)` is
+            // the pullback of two halves. The bytes emitted in iteration
+            // k+1 are a concatenation of `SEP_k+1` and `BODY_k+1`; if
+            // `SEP_k+1` is the empty word, the concatenation of
+            // `BODY_k` and `BODY_k+1` must remain a single contiguous
+            // span. Hence the NoSpace marker.
+            let separator_leading_seq: Option<&[Production]> = match content.as_ref() {
+                Production::Seq { members } if members.len() >= 2 => {
+                    let first = &members[0];
+                    let is_separator_slot = match first {
+                        Production::Choice { members } => {
+                            members.iter().any(|m| matches!(m, Production::Blank))
+                        }
+                        Production::Optional { .. } => true,
+                        _ => false,
+                    };
+                    if is_separator_slot {
+                        Some(members.as_slice())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+
             let mut emitted_any = false;
             loop {
                 let cursor_snap = cursor.consumed.clone();
                 let out_snap = out.snapshot();
                 let consumed_before = cursor.consumed.iter().filter(|&&c| c).count();
-                let result =
-                    emit_production(protocol, schema, grammar, vertex_id, content, cursor, out);
+                let result: Result<(), ParseError> =
+                    if let Some(seq_members) = separator_leading_seq {
+                        // Emit the separator slot first and observe
+                        // whether it contributed any Lit. If not, push
+                        // a NoSpace marker before walking the remaining
+                        // SEQ members. The OutputSnapshot here covers
+                        // only the separator's emission window.
+                        let pre_sep = out.snapshot();
+                        let sep_result = emit_production(
+                            protocol,
+                            schema,
+                            grammar,
+                            vertex_id,
+                            &seq_members[0],
+                            cursor,
+                            out,
+                        );
+                        match sep_result {
+                            Err(e) => Err(e),
+                            Ok(()) => {
+                                if !out.lit_emitted_since(pre_sep) {
+                                    out.no_space();
+                                }
+                                let mut rest_result = Ok(());
+                                for member in &seq_members[1..] {
+                                    rest_result = emit_production(
+                                        protocol, schema, grammar, vertex_id, member, cursor,
+                                        out,
+                                    );
+                                    if rest_result.is_err() {
+                                        break;
+                                    }
+                                }
+                                rest_result
+                            }
+                        }
+                    } else {
+                        emit_production(protocol, schema, grammar, vertex_id, content, cursor, out)
+                    };
                 let consumed_after = cursor.consumed.iter().filter(|&&c| c).count();
                 if result.is_err() || consumed_after == consumed_before {
                     cursor.consumed = cursor_snap;
@@ -1941,6 +2012,12 @@ enum Token {
     /// "Break a line here if not already at line start" — used after
     /// statements/declarations and after open braces.
     LineBreak,
+    /// Suppress the next inter-Lit separator. Pushed by the REPEAT
+    /// walker when an iteration's "separator slot" (a CHOICE-with-BLANK
+    /// or OPTIONAL at SEQ position 0) emitted zero content tokens, so
+    /// the categorical reading is "no source-level separator existed
+    /// between these two sibling iterations of the body".
+    NoSpace,
 }
 
 struct Output<'a> {
@@ -2020,6 +2097,26 @@ impl<'a> Output<'a> {
         self.tokens.truncate(snap.tokens_len);
     }
 
+    /// True iff at least one `Token::Lit` was pushed since `snap`.
+    /// Control-only emissions (LineBreak, IndentOpen / IndentClose,
+    /// NoSpace) do not count as content. Used by the REPEAT walker
+    /// to detect that a "separator slot" CHOICE picked its BLANK
+    /// alternative, so the next iteration's content can be marked
+    /// tight against the previous iteration's content.
+    fn lit_emitted_since(&self, snap: OutputSnapshot) -> bool {
+        self.tokens[snap.tokens_len..]
+            .iter()
+            .any(|t| matches!(t, Token::Lit(_)))
+    }
+
+    /// Push a marker that suppresses the next inter-Lit separator the
+    /// layout pass would otherwise insert. Used to encode "no source-
+    /// level separator was emitted between these two Lits" without
+    /// having to make per-grammar adjacency decisions in the layout.
+    fn no_space(&mut self) {
+        self.tokens.push(Token::NoSpace);
+    }
+
     fn finish(self) -> Vec<u8> {
         layout(&self.tokens, self.policy)
     }
@@ -2043,6 +2140,10 @@ fn layout(tokens: &[Token], policy: &FormatPolicy) -> Vec<u8> {
     // (`f(-1.0)`) rather than a spaced binary operator (`a - b`).
     let mut last_was_in_operand_position = true;
     let mut expecting_operand = true;
+    // Set when a `Token::NoSpace` marker is seen; cleared when the next
+    // Lit consumes it. While set, suppress the policy separator that
+    // would otherwise be inserted before the next Lit.
+    let mut suppress_next_separator = false;
     let newline = policy.newline.as_bytes();
     let separator = policy.separator.as_bytes();
 
@@ -2064,14 +2165,20 @@ fn layout(tokens: &[Token], policy: &FormatPolicy) -> Vec<u8> {
                     expecting_operand = true;
                 }
             }
+            Token::NoSpace => {
+                suppress_next_separator = true;
+            }
             Token::Lit(value) => {
                 if at_line_start {
                     bytes.extend(std::iter::repeat_n(b' ', indent * policy.indent_width));
                 } else if let Some(prev) = last_lit {
-                    if needs_space_between(prev, value, last_was_in_operand_position) {
+                    if !suppress_next_separator
+                        && needs_space_between(prev, value, last_was_in_operand_position)
+                    {
                         bytes.extend_from_slice(separator);
                     }
                 }
+                suppress_next_separator = false;
                 bytes.extend_from_slice(value.as_bytes());
                 at_line_start = false;
                 last_was_in_operand_position = expecting_operand;

--- a/crates/panproto-parse/tests/emit_pretty_tight_repeat.rs
+++ b/crates/panproto-parse/tests/emit_pretty_tight_repeat.rs
@@ -1,0 +1,50 @@
+//! Regression: `emit_pretty` keeps two sibling REPEAT iterations
+//! tight when the iteration body's leading "separator slot" emits
+//! zero content tokens (its `CHOICE` picked `BLANK`, equivalently its
+//! `OPTIONAL` was absent).
+//!
+//! Pre-fix, ABC's `beam` rule (`SEQ(_nte_or_chrd,
+//! REPEAT1(SEQ(CHOICE(BEAM_SEPARATOR, BLANK), _nte_or_chrd)))`) emitted
+//! consecutive note letters separated by the policy separator
+//! (`"CDEF"` rendered as `"C D E F"`) because the layout pass had no
+//! way to distinguish "no source-level separator was present here"
+//! from "two adjacent word-like tokens need to be lexically separated."
+//!
+//! The walker now detects "separator-leading SEQ" REPEAT bodies (the
+//! first SEQ element is `CHOICE` containing `BLANK`, or an
+//! `OPTIONAL`), emits the separator slot first while observing
+//! whether any content token was produced, and pushes a `Token::NoSpace`
+//! marker before the remaining SEQ members when the slot was empty.
+//! The layout pass consumes the marker and suppresses the inter-Lit
+//! separator for that pair, encoding the categorical reading that the
+//! iteration boundary had no source-level separator.
+
+#![cfg(all(feature = "grammars", feature = "lang-abc"))]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use panproto_parse::ParserRegistry;
+
+const ABC_BEAM_SRC: &[u8] = b"X:1\nT:T\nM:4/4\nK:C\nCDEF GABc|\n";
+
+#[test]
+fn emit_pretty_abc_beam_notes_render_tight() {
+    let reg = ParserRegistry::new();
+    let schema = reg
+        .parse_with_protocol("abc", ABC_BEAM_SRC, "audit.abc")
+        .expect("parse");
+
+    let bytes = reg
+        .emit_pretty_with_protocol("abc", &schema)
+        .expect("emit_pretty");
+    let text = String::from_utf8(bytes).expect("utf8");
+
+    // At least one consecutive same-beam note pair must render tight.
+    // Pre-fix output `"C D E F G A B c"` had a space between every
+    // adjacent letter and so failed all four pair checks.
+    let pre_fix_loose = ["C D", "D E", "E F", "G A", "A B", "B c"];
+    let still_loose = pre_fix_loose.iter().filter(|p| text.contains(*p)).count();
+    assert!(
+        still_loose < pre_fix_loose.len(),
+        "every adjacent same-beam note pair still has a space inserted between it (pre-fix regression): {text:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- For REPEAT / REPEAT1 bodies of shape `SEQ(SEP, BODY)` where `SEP` is `CHOICE` containing `BLANK` (or an `OPTIONAL`), the source-level separator between iterations is syntactically optional. When the runtime alternative for the separator slot emits zero content tokens (BLANK picked), there was no source separator between two adjacent iterations; the layout pass must respect that.
- The REPEAT walker now structurally recognises separator-leading SEQ bodies, emits the separator slot first while observing whether any content token was produced, and pushes a new `Token::NoSpace` marker before the remaining SEQ members when the slot was empty. Layout consumes the marker and suppresses the inter-Lit separator for that pair.
- Bodies whose first SEQ member is not `CHOICE`-with-BLANK / `OPTIONAL` (e.g. `commaSep1`'s `SEQ(STRING ",", SYMBOL)`) take the original code path unchanged.
- Bump workspace to 0.48.12. Stacked on #124.

Improves #113 (ABC beam piece).

## Test plan
- [x] Regression test at `crates/panproto-parse/tests/emit_pretty_tight_repeat.rs` asserts ABC beam notes no longer all separate with spaces.
- [x] All 59 panproto-parse tests pass under `--features grammars,lang-abc,lang-csound,lang-supercollider,lang-lilypond,lang-qvr`.
- [ ] CI: clippy, nextest, fmt, version consistency.