### PR TITLE
fix(parse): prefer BLANK over STRING-only CHOICE alt when cursor exhausted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.48.13] - 2026-05-21
+
+### Fixed
+
+- **`emit_pretty` no longer emits phantom trailing punctuation when a CHOICE includes BLANK and the cursor is exhausted** (`panproto-parse::emit_pretty`): the `chose-alt-fingerprint` constraint is built per vertex from the concatenated interstitial fragments. A rule like QVR's `sample_step`, whose body ends in `..., REPEAT(SEQ(",", arg)), CHOICE(",", BLANK)` (the canonical `commaSep1`-with-optional-trailing-comma shape), deposits one `","` into the fingerprint blob per arg-separator gap. The trailing CHOICE then scored `","` over BLANK (one literal match per recorded separator vs zero), and `f(1.0, 2.0, 3.0)` rendered as `f(1.0, 2.0, 3.0,)` with a phantom trailing comma. The literal-blob discriminator is intrinsically position-blind across multiple positional CHOICEs at the same vertex, so the cursor-exhaustion gate now fires first: when no unconsumed edges remain AND `BLANK` is one of the alternatives, the only categorically correct alt is `BLANK`, regardless of what literal tokens appear earlier in the vertex's interstitials. Regression test at `crates/panproto-parse/tests/emit_pretty_trailing_punctuation.rs`. Improves #113 (commaSep1 trailing comma family across grammars).
+
 ## [0.48.12] - 2026-05-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.12"
+version = "0.48.13"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.48.12", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.48.12", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.48.12", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.48.12", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.48.12", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.48.12", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.48.12", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.48.12", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.48.12", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.48.12", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.48.12", path = "crates/panproto-core" }
-panproto-io = { version = "0.48.12", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.48.12", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.48.12", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.48.12", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.48.12", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.48.12", path = "crates/panproto-parse" }
-panproto-project = { version = "0.48.12", path = "crates/panproto-project" }
-panproto-git = { version = "0.48.12", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.48.12", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.48.12", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.48.12", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.48.12", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.48.13", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.48.13", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.48.13", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.48.13", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.48.13", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.48.13", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.48.13", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.48.13", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.48.13", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.48.13", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.48.13", path = "crates/panproto-core" }
+panproto-io = { version = "0.48.13", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.48.13", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.48.13", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.48.13", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.48.13", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.48.13", path = "crates/panproto-parse" }
+panproto-project = { version = "0.48.13", path = "crates/panproto-project" }
+panproto-git = { version = "0.48.13", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.48.13", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.48.13", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.48.13", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.48.13", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.48.12
+version:            0.48.13
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.48.12",
+  "version": "0.48.13",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.12", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/src/emit_pretty.rs
+++ b/crates/panproto-parse/src/emit_pretty.rs
@@ -1505,6 +1505,31 @@ fn pick_choice_with_cursor<'a>(
                 .map(|c| c.value.split_whitespace().collect())
         })
         .unwrap_or_default();
+    // Cursor-exhaustion BLANK-preference: when all cursor edges have
+    // been consumed AND `BLANK` is one of the alternatives, the only
+    // alt that won't introduce a non-existent child is `BLANK`.
+    //
+    // This gate fires before the literal-blob discriminator because
+    // the fingerprint is shared across every CHOICE position in the
+    // vertex's rule body: a vertex like `sample_step` that ends in
+    // `..., REPEAT(SEQ(",", arg)), CHOICE(",", BLANK)` records all of
+    // its `","` interstitials in a single blob, so the literal-score
+    // matcher would otherwise prefer `","` for the trailing CHOICE
+    // even when the source had no trailing comma. By the time the
+    // emitter reaches the trailing CHOICE, the REPEAT has consumed
+    // every arg edge in cursor order; the residual unconsumed multiset
+    // is empty; and the categorical reading of a CHOICE-with-BLANK at
+    // a position with no remaining children is the no-op alternative.
+    let any_unconsumed = cursor
+        .edges
+        .iter()
+        .enumerate()
+        .any(|(i, _)| !cursor.consumed[i]);
+    let blank_present = alternatives.iter().any(|a| matches!(a, Production::Blank));
+    if !any_unconsumed && blank_present {
+        return alternatives.iter().find(|a| matches!(a, Production::Blank));
+    }
+
     if !constraint_blob.is_empty() {
         // Primary score: literal-token match length. This dominates
         // alt selection so existing language tests that depend on

--- a/crates/panproto-parse/tests/emit_pretty_trailing_punctuation.rs
+++ b/crates/panproto-parse/tests/emit_pretty_trailing_punctuation.rs
@@ -1,0 +1,57 @@
+//! Regression: `emit_pretty` picks `BLANK` over a STRING-only
+//! alternative when the cursor has no unconsumed children and the
+//! CHOICE includes `BLANK`.
+//!
+//! Pre-fix, QVR's `sample_step` ended its argument list with a
+//! `CHOICE(",", BLANK)` (optional trailing comma). The
+//! `chose-alt-fingerprint` constraint that drives CHOICE dispatch is
+//! built from the vertex's interstitial fragments joined into one
+//! blob; an `f(1.0, 2.0, 3.0)` invocation deposited `","` three times
+//! into that blob (once per arg-separator gap). The trailing CHOICE
+//! then scored `","` higher than `BLANK` (3 vs 0 literal matches)
+//! and emitted `f(1.0, 2.0, 3.0,)` with a phantom trailing comma.
+//!
+//! The fix gates CHOICE dispatch on the cursor's residual
+//! unconsumed multiset: when no edges remain to discriminate the
+//! alternatives AND `BLANK` is one of them, the only categorically
+//! correct alt is `BLANK`. The literal-blob fingerprint cannot
+//! distinguish multiple positional CHOICEs at the same vertex, so the
+//! cursor-exhaustion gate is the structural invariant.
+
+#![cfg(all(feature = "grammars", feature = "lang-qvr"))]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use panproto_parse::ParserRegistry;
+
+const QVR_TRAILING_COMMA: &[u8] = b"\
+program p : X -> X:
+    sample a <- f(1.0, 2.0, 3.0)
+    return a
+";
+
+#[test]
+fn emit_pretty_does_not_emit_phantom_trailing_comma_in_commasep1() {
+    let reg = ParserRegistry::new();
+    let schema = reg
+        .parse_with_protocol("qvr", QVR_TRAILING_COMMA, "trail.qvr")
+        .expect("parse");
+
+    let bytes = reg
+        .emit_pretty_with_protocol("qvr", &schema)
+        .expect("emit_pretty");
+    let text = String::from_utf8(bytes).expect("utf8");
+
+    // The phantom trailing comma rendered as `3.0,)`. With the fix the
+    // closing paren immediately follows the last arg.
+    assert!(
+        !text.contains("3.0,)") && !text.contains("3.0 ,)"),
+        "phantom trailing comma in commaSep1 output: {text:?}"
+    );
+    // Sanity: all three args still survive.
+    for arg in ["1.0", "2.0", "3.0"] {
+        assert!(
+            text.contains(arg),
+            "arg {arg:?} dropped: {text:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- The `chose-alt-fingerprint` constraint is built per vertex from concatenated interstitial fragments. A rule that ends in `REPEAT(SEQ(",", arg)), CHOICE(",", BLANK)` (the commaSep1-with-optional-trailing-comma shape) deposits one `","` per arg-separator gap into the fingerprint blob, so the trailing CHOICE scored `","` over BLANK and emitted a phantom trailing comma: `f(1.0, 2.0, 3.0)` became `f(1.0, 2.0, 3.0,)`.
- The fix gates CHOICE dispatch on cursor exhaustion: when no unconsumed edges remain AND `BLANK` is among the alternatives, the only categorically correct alt is `BLANK`. This is structurally invariant — the cursor having no more children to discriminate is the witness — and does not depend on the lossy literal-blob shared across positional CHOICEs.
- Bump workspace to 0.48.13. Stacked on #125.

Improves #113 (commaSep1 trailing comma family across all grammars with that shape).

## Test plan
- [x] Regression test at `crates/panproto-parse/tests/emit_pretty_trailing_punctuation.rs`.
- [x] All 60 panproto-parse tests pass under `--features grammars,lang-abc,lang-csound,lang-supercollider,lang-lilypond,lang-qvr`.
- [ ] CI: clippy, nextest, fmt, version consistency.