### PR TITLE
fix(parse): split trailing newlines off literal-value Lits in emit_pretty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.48.14] - 2026-05-21
+
+### Fixed
+
+- **`emit_pretty` splits trailing newlines off `literal-value` Lits and routes them through `Token::LineBreak`** (`panproto-parse::emit_pretty`): a vertex carrying a `literal-value` constraint and no structural children emits its captured text directly via the leaf shortcut. For grammars whose terminal-like rules absorb a trailing newline (e.g. ABC's `reference_number_line` matching `"X:1\n"`), the captured value contained an embedded `\n`. Pushing it as `Lit("X:1\n")` left the newline character in the output but the layout pass then ran `needs_space_between("X:1\n", "T:")` against the next Lit; the fall-through "keep operator runs apart" rule inserted the policy separator at column 0 of the new line, rendering `X:1\n T:` instead of `X:1\nT:`. `Output::token` now strips trailing newlines off any non-pure-newline Lit value, emits the trimmed prefix as a `Lit`, and pushes a `LineBreak` for the newline tail. Layout treats `LineBreak` as a line-state reset, so the next Lit starts at column 0 with no intervening separator. Regression test at `crates/panproto-parse/tests/emit_pretty_literal_trailing_newline.rs`. Improves #113 (ABC tune-header leading-space piece).
+
 ## [0.48.13] - 2026-05-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.13"
+version = "0.48.14"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.48.13", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.48.13", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.48.13", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.48.13", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.48.13", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.48.13", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.48.13", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.48.13", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.48.13", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.48.13", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.48.13", path = "crates/panproto-core" }
-panproto-io = { version = "0.48.13", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.48.13", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.48.13", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.48.13", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.48.13", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.48.13", path = "crates/panproto-parse" }
-panproto-project = { version = "0.48.13", path = "crates/panproto-project" }
-panproto-git = { version = "0.48.13", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.48.13", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.48.13", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.48.13", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.48.13", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.48.14", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.48.14", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.48.14", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.48.14", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.48.14", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.48.14", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.48.14", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.48.14", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.48.14", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.48.14", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.48.14", path = "crates/panproto-core" }
+panproto-io = { version = "0.48.14", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.48.14", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.48.14", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.48.14", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.48.14", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.48.14", path = "crates/panproto-parse" }
+panproto-project = { version = "0.48.14", path = "crates/panproto-project" }
+panproto-git = { version = "0.48.14", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.48.14", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.48.14", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.48.14", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.48.14", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.48.13
+version:            0.48.14
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.48.13",
+  "version": "0.48.14",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.13", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/src/emit_pretty.rs
+++ b/crates/panproto-parse/src/emit_pretty.rs
@@ -2080,6 +2080,30 @@ impl<'a> Output<'a> {
             return;
         }
 
+        // A captured literal value (typically a vertex's `literal-value`
+        // constraint covering the full source span of a terminal-like
+        // rule, e.g. abc's `reference_number_line` matching `"X:1\n"`)
+        // may contain trailing newlines. Splitting the trailing newlines
+        // off as a `LineBreak` lets the layout pass treat the next Lit
+        // as starting a new line; otherwise the next Lit pair would
+        // trigger `needs_space_between` against the embedded `\n` and
+        // insert the policy separator at column 0 of the new line.
+        let trimmed = value.trim_end_matches(|c: char| c == '\n' || c == '\r');
+        let trailing_newlines = value.len() - trimmed.len();
+        if trailing_newlines > 0 && !trimmed.is_empty() {
+            if self.policy.indent_close.iter().any(|t| t == trimmed) {
+                self.tokens.push(Token::IndentClose);
+            }
+            self.tokens.push(Token::Lit(trimmed.to_owned()));
+            if self.policy.indent_open.iter().any(|t| t == trimmed) {
+                self.tokens.push(Token::IndentOpen);
+            } else if self.policy.line_break_after.iter().any(|t| t == trimmed) {
+                // already emitting a LineBreak below for the trailing \n
+            }
+            self.tokens.push(Token::LineBreak);
+            return;
+        }
+
         if self.policy.indent_close.iter().any(|t| t == value) {
             self.tokens.push(Token::IndentClose);
         }

--- a/crates/panproto-parse/tests/emit_pretty_literal_trailing_newline.rs
+++ b/crates/panproto-parse/tests/emit_pretty_literal_trailing_newline.rs
@@ -1,0 +1,55 @@
+//! Regression: a literal-value Lit that ends in trailing newlines
+//! pushes a `LineBreak` token for the newline tail rather than
+//! keeping the newline characters inside the Lit.
+//!
+//! Pre-fix, ABC's `reference_number_line` matched `"X:1\n"` and
+//! recorded that whole span as the vertex's `literal-value`. The
+//! emitter's leaf shortcut pushed it as `Lit("X:1\n")`. The layout
+//! pass then ran `needs_space_between("X:1\n", "T:")` for the
+//! following tune-header line; neither token was punctuation in the
+//! recognised classes, so the fall-through "keep operator runs apart"
+//! rule kicked in and inserted a separator at column 0 of the next
+//! line: `"X:1\n T: Test\n..."`. Only the first inter-line gap was
+//! affected, because every other line's terminator went through the
+//! `STRING "\n"` `_NL` rule which my newline-as-LineBreak fix had
+//! already routed correctly.
+//!
+//! The fix: `Output::token` now splits a trailing-newline tail off
+//! any Lit value, emits the trimmed prefix as a `Lit`, and pushes a
+//! `LineBreak` for the newline tail. Layout treats `LineBreak` as a
+//! line-state reset, so the next Lit starts at column 0 with no
+//! intervening policy separator.
+
+#![cfg(all(feature = "grammars", feature = "lang-abc"))]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use panproto_parse::ParserRegistry;
+
+const ABC_SRC: &[u8] = b"X:1\nT:Test\nM:4/4\nK:C\nCDEF\n";
+
+#[test]
+fn emit_pretty_strips_trailing_newline_from_literal_lit() {
+    let reg = ParserRegistry::new();
+    let schema = reg
+        .parse_with_protocol("abc", ABC_SRC, "audit.abc")
+        .expect("parse");
+
+    let bytes = reg
+        .emit_pretty_with_protocol("abc", &schema)
+        .expect("emit_pretty");
+    let text = String::from_utf8(bytes).expect("utf8");
+
+    // The pre-fix output was `"X:1\n T: Test\n..."`. After the fix
+    // every newline-prefixed line starts at column 0.
+    assert!(
+        !text.contains("\n T:") && !text.contains("\n M:") && !text.contains("\n K:"),
+        "leading space after a line break (literal Lit with embedded newline regression): {text:?}"
+    );
+    // Sanity: the header content still survives.
+    for keyword in ["X:", "T:", "M:", "K:"] {
+        assert!(
+            text.contains(keyword),
+            "header keyword {keyword:?} dropped: {text:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- A vertex carrying a `literal-value` constraint and no structural children emits its captured text directly via the leaf shortcut. For grammars whose terminal-like rules absorb a trailing newline (e.g. ABC's `reference_number_line` matching `"X:1\n"`), the captured value contained an embedded `\n`. Pushing it as `Lit("X:1\n")` left the newline character in the output but the layout pass then ran `needs_space_between("X:1\n", "T:")` and the fall-through "keep operator runs apart" rule inserted the policy separator at column 0 of the new line.
- `Output::token` now strips trailing newlines off any non-pure-newline Lit value, emits the trimmed prefix as a `Lit`, and pushes a `LineBreak` for the newline tail. Layout treats `LineBreak` as a line-state reset.
- Bump workspace to 0.48.14. Stacked on #126.

Improves #113 (ABC tune-header leading-space piece).

## Test plan
- [x] Regression test at `crates/panproto-parse/tests/emit_pretty_literal_trailing_newline.rs`.
- [x] All 60 panproto-parse tests pass under `--features grammars,lang-abc,lang-csound,lang-supercollider,lang-lilypond,lang-qvr`.
- [ ] CI: clippy, nextest, fmt, version consistency.