### PR TITLE
feat(grammars): register .musicxml extension on the xml protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.48.15] - 2026-05-21
+
+### Added
+
+- **`.musicxml` extension dispatches to the `xml` protocol** (`grammars.toml`): per the W3C Music Notation Community Group's MusicXML 4.0 specification (https://www.w3.org/2021/06/musicxml40/tutorial/file-extensions/), a `.musicxml` file is plain XML; the schema (DTD / XSD) constrains element names and attribute values, not the lexical form. The existing `tree-sitter-xml` grammar therefore parses MusicXML scores without modification — no new vendored grammar is required. The extension dispatcher now routes `.musicxml` files to the `xml` protocol so `parse_with_protocol("xml", bytes, "score.musicxml")` and `parse_file("score.musicxml", bytes)` both succeed. The compressed `.mxl` container (ZIP-of-MusicXML) is not registered: it requires unzipping before any parser can see the XML payload, which is a transformation outside the grammar surface. Regression test at `crates/panproto-parse/tests/musicxml_parse.rs` parses a representative MusicXML 4.0 "hello world" score (partwise score, one part, one measure, one C4 whole note) end-to-end and confirms structural recovery. Partially addresses #112.
+
 ## [0.48.14] - 2026-05-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.14"
+version = "0.48.15"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.48.14", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.48.14", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.48.14", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.48.14", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.48.14", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.48.14", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.48.14", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.48.14", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.48.14", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.48.14", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.48.14", path = "crates/panproto-core" }
-panproto-io = { version = "0.48.14", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.48.14", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.48.14", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.48.14", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.48.14", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.48.14", path = "crates/panproto-parse" }
-panproto-project = { version = "0.48.14", path = "crates/panproto-project" }
-panproto-git = { version = "0.48.14", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.48.14", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.48.14", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.48.14", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.48.14", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.48.15", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.48.15", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.48.15", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.48.15", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.48.15", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.48.15", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.48.15", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.48.15", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.48.15", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.48.15", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.48.15", path = "crates/panproto-core" }
+panproto-io = { version = "0.48.15", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.48.15", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.48.15", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.48.15", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.48.15", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.48.15", path = "crates/panproto-parse" }
+panproto-project = { version = "0.48.15", path = "crates/panproto-project" }
+panproto-git = { version = "0.48.15", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.48.15", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.48.15", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.48.15", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.48.15", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.48.14
+version:            0.48.15
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.48.14",
+  "version": "0.48.15",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.48.15", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.48.15", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.48.15", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.48.15", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.48.15", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.48.15", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.48.15", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.48.15", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.48.15", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.48.14", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.48.15", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/tests/musicxml_parse.rs
+++ b/crates/panproto-parse/tests/musicxml_parse.rs
@@ -1,0 +1,98 @@
+//! `.musicxml` files dispatch to the existing tree-sitter-xml grammar.
+//!
+//! Per the W3C Music Notation Community Group's MusicXML 4.0
+//! specification, a `.musicxml` file is plain XML; the schema
+//! (DTD / XSD) constrains element names and attribute values, not the
+//! lexical form. So a fresh grammar is unnecessary — the existing
+//! tree-sitter-xml grammar handles the file as-is. This test confirms
+//! the extension dispatcher routes `.musicxml` to `xml` and that a
+//! representative fragment recovers the expected structural kinds.
+
+#![cfg(all(feature = "grammars", feature = "lang-xml"))]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use panproto_parse::ParserRegistry;
+
+/// A minimal but well-formed MusicXML excerpt: declaration, partwise
+/// score with one part containing one measure of a single C4 quarter
+/// note. Drawn from the MusicXML 4.0 "hello world" sample at
+/// https://www.w3.org/2021/06/musicxml40/tutorial/hello-world/.
+const HELLO_MUSICXML: &[u8] = br#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC
+    "-//Recordare//DTD MusicXML 4.0 Partwise//EN"
+    "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Music</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>
+"#;
+
+#[test]
+fn musicxml_extension_routes_to_xml_protocol() {
+    let reg = ParserRegistry::new();
+    let detected = reg.detect_language(std::path::Path::new("hello.musicxml"));
+    assert_eq!(
+        detected,
+        Some("xml"),
+        ".musicxml extension must dispatch to the xml protocol"
+    );
+}
+
+#[test]
+fn musicxml_parses_through_xml_grammar() {
+    let reg = ParserRegistry::new();
+    let schema = reg
+        .parse_with_protocol("xml", HELLO_MUSICXML, "hello.musicxml")
+        .expect("xml parser must accept a well-formed MusicXML score");
+
+    let kinds: std::collections::BTreeSet<String> = schema
+        .vertices
+        .values()
+        .map(|v| v.kind.to_string())
+        .collect();
+
+    // tree-sitter-xml recognises elements as `STag` / `ETag` /
+    // `element` (the exact set varies with the grammar version;
+    // present here are the structural names common to every release
+    // of tree-sitter-xml that ships in panproto-grammars).
+    assert!(
+        kinds.contains("document"),
+        "musicxml schema missing `document` root; got {kinds:?}"
+    );
+    assert!(
+        kinds.contains("element"),
+        "musicxml schema missing `element`; got {kinds:?}"
+    );
+    // Non-trivial structural recovery: the score has many nested
+    // elements, attributes, and a doctype.
+    assert!(schema.vertices.len() >= 20, "non-trivial MusicXML schema");
+}

--- a/grammars.toml
+++ b/grammars.toml
@@ -1033,7 +1033,16 @@ extensions = []
 
 [xml]
 repo = "https://github.com/tree-sitter-grammars/tree-sitter-xml"
-extensions = ["xml", "xsl", "xslt"]
+# `musicxml` is the uncompressed file extension defined by the W3C
+# Music Notation Community Group's MusicXML 4.0 specification
+# (https://www.w3.org/2021/06/musicxml40/tutorial/file-extensions/).
+# Per that spec, a `.musicxml` file is plain XML with no additional
+# syntactic surface — the schema (DTD / XSD) constrains element names
+# and attribute values, not the lexical form — so the existing
+# tree-sitter-xml grammar parses it without modification. The `.mxl`
+# extension is the compressed ZIP-of-MusicXML container; that needs
+# unzipping before parse, so it is not registered here.
+extensions = ["xml", "xsl", "xslt", "musicxml"]
 directory = "xml"
 
 [yaml]


### PR DESCRIPTION
## Summary

Per the W3C Music Notation Community Group's MusicXML 4.0 specification (https://www.w3.org/2021/06/musicxml40/tutorial/file-extensions/), a `.musicxml` file is plain XML; the schema (DTD / XSD) constrains element names and attribute values, not the lexical form. The existing `tree-sitter-xml` grammar parses MusicXML scores as-is, so no new vendored grammar is required — registering the extension is enough to make `parse_with_protocol("xml", bytes, "score.musicxml")` and `parse_file("score.musicxml", bytes)` both succeed.

The compressed `.mxl` container (ZIP-of-MusicXML) is intentionally not registered: it requires unzipping before any parser can see the XML payload, which is a transformation outside the grammar surface.

Bump workspace to 0.48.15. Stacked on #127.

Partially addresses #112. The Reaper RPP piece is intentionally out of scope: no publicly available tree-sitter grammar exists, and the RPP format has no formal spec to author one from without inventing structure.

## Test plan
- [x] Regression test at `crates/panproto-parse/tests/musicxml_parse.rs` parses a representative MusicXML 4.0 hello-world score and confirms structural recovery (`document`, `element`, 20+ vertices).
- [x] `detect_language("hello.musicxml")` returns `Some("xml")`.
- [ ] CI: clippy, nextest, fmt, version consistency.