### PR TITLE
fix: Nickel infinite recursion, macrocall args, JS semicolons (0.50.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.50.3] - 2026-05-25
+
+### Fixed
+
+- **Nickel contract modules no longer infinite-recurse on import** (`panproto-lens-dsl`, `panproto-theory-dsl`): the 0.50.1 fix (#151) replaced field-shorthand exports with explicit assignments (`Lens = Lens,`), but Nickel's record scope shadows enclosing `let`-bindings when field and variable names coincide, turning every export into a self-referential binding. Restructured both `lens.ncl` and `theory.ncl` as flat records with all definitions inline (no `let`-chain), and prefixed combinator parameters with `_` to avoid field-name collisions (`fun _old _new => { old = _old, new = _new }`). Six new Nickel evaluation regression tests cover individual combinators, rule patterns, and exhaustive export accessibility. Closes #154.
+- **`emit_pretty` renders Julia parenthesised macrocall arguments** (`panproto-parse`): the grammar rule for `macrocall_expression` references `macro_argument_list`, but tree-sitter's parser also produces `argument_list` children for the short form `@trace(args)`. Unconsumed structural children left after the grammar-rule walk are now emitted as a fallback, so the argument list survives even when no grammar alternative matches it. Closes #153.
+- **`emit_pretty` inserts semicolons for JavaScript ASI** (`panproto-parse`): the `_automatic_semicolon` external scanner token was falling through the heuristic fallback silently. External hidden rules whose name contains "semicolon" now emit `;`. Two regression tests verify semicolon presence and error-free re-parse. Closes #155.
+- **`@` sigil no longer inserts a spurious space before the macro name** (`panproto-parse`): added `@` and `#` to the set of prefix-sigil punctuation that suppresses trailing whitespace in the layout policy.
+
 ## [0.50.2] - 2026-05-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "anyhow",
  "miette",
@@ -1994,7 +1994,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "ciborium",
  "panproto-core",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "divan",
  "insta",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "divan",
  "proptest",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "chumsky",
  "divan",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "divan",
  "miette",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "divan",
  "git2",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "git2",
  "miette",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "cc",
  "divan",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-jit"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "divan",
  "inkwell",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "divan",
  "insta",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "divan",
  "miette",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-llvm"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "divan",
  "inkwell",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "divan",
  "memchr",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "blake3",
  "divan",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "blake3",
  "divan",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-repl"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "miette",
  "panproto-gat",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "divan",
  "miette",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "blake3",
  "divan",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.50.2"
+version = "0.50.3"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.50.2", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.50.2", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.50.2", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.50.2", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.50.2", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.50.2", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.50.2", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.50.2", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.50.2", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.50.2", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.50.2", path = "crates/panproto-core" }
-panproto-io = { version = "0.50.2", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.50.2", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.50.2", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.50.2", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.50.2", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.50.2", path = "crates/panproto-parse" }
-panproto-project = { version = "0.50.2", path = "crates/panproto-project" }
-panproto-git = { version = "0.50.2", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.50.2", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.50.2", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.50.2", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.50.2", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.50.3", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.50.3", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.50.3", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.50.3", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.50.3", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.50.3", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.50.3", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.50.3", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.50.3", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.50.3", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.50.3", path = "crates/panproto-core" }
+panproto-io = { version = "0.50.3", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.50.3", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.50.3", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.50.3", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.50.3", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.50.3", path = "crates/panproto-parse" }
+panproto-project = { version = "0.50.3", path = "crates/panproto-project" }
+panproto-git = { version = "0.50.3", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.50.3", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.50.3", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.50.3", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.50.3", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.50.2
+version:            0.50.3
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.50.2",
+  "version": "0.50.3",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.2", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.50.3", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.2", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.50.3", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.2", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.50.3", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.50.2", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.50.3", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.2", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.50.3", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.2", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.50.3", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.2", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.50.3", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.2", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.50.3", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.2", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.50.3", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.2", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.50.3", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-lens-dsl/contracts/lens.ncl
+++ b/crates/panproto-lens-dsl/contracts/lens.ncl
@@ -4,491 +4,386 @@
 #   let L = import "panproto/lens.ncl" in
 #   { ... } | L.Lens
 
-# -- Coercion classification --
-# Use as: coercion = L.iso, coercion = L.projection, etc.
-let iso = "iso" in
-let retraction = "retraction" in
-let projection = "projection" in
-let opaque = "opaque" in
-
-let Coercion = std.contract.from_predicate (fun x =>
-  x == "iso" || x == "retraction" || x == "projection" || x == "opaque"
-) in
-
-# -- Step contracts --
-
-let RenameSpec = {
-  old | String,
-  new | String,
-} in
-
-let AddFieldSpec = {
-  name | String,
-  kind | String,
-  fallback | optional,
-  expr | String | optional,
-} in
-
-let ApplyExprSpec = {
-  field | String,
-  expr | String,
-  inverse | String | optional,
-  coercion | Coercion | optional,
-} in
-
-let ComputeFieldSpec = {
-  target | String,
-  expr | String,
-  inverse | String | optional,
-  coercion | Coercion | optional,
-} in
-
-let HoistSpec = {
-  parent | String,
-  intermediate | String,
-  child | String,
-} in
-
-let NestSpec = {
-  parent | String,
-  child | String,
-  intermediate | String,
-  intermediate_kind | String,
-  edge_kind | String,
-  old_edge_name | String | optional,
-  parent_to_intermediate | String | optional,
-  intermediate_to_child | String | optional,
-} in
-
-let PullbackSpec = {
-  name | String,
-  domain | String,
-  codomain | String,
-  sort_map | { _ : String } | default = {},
-  op_map | { _ : String } | default = {},
-} in
-
-let CoerceSortSpec = {
-  sort | String,
-  target_kind | String,
-  expr | String,
-  inverse | String | optional,
-  coercion | Coercion,
-} in
-
-let MergeSortsSpec = {
-  sort_a | String,
-  sort_b | String,
-  merged | String,
-  expr | String,
-} in
-
-let AddSortSpec = {
-  name | String,
-  kind | String,
-  fallback | optional,
-} in
-
-let AddOpSpec = {
-  name | String,
-  src | String,
-  tgt | String,
-  kind | String,
-} in
-
-let EquationSpec = {
-  name | String,
-  lhs | String,
-  rhs | String,
-} in
-
-# A step is a record with exactly one of these keys set.
-# We use an open contract: each field is optional, and users
-# provide exactly one per step object.
-let Step = {
-  remove_field | String | optional,
-  rename_field | RenameSpec | optional,
-  add_field | AddFieldSpec | optional,
-  apply_expr | ApplyExprSpec | optional,
-  compute_field | ComputeFieldSpec | optional,
-  hoist_field | HoistSpec | optional,
-  nest_field | NestSpec | optional,
-  scoped | { focus | String, inner | Array Dyn } | optional,
-  pullback | PullbackSpec | optional,
-  coerce_sort | CoerceSortSpec | optional,
-  merge_sorts | MergeSortsSpec | optional,
-  add_sort | AddSortSpec | optional,
-  drop_sort | String | optional,
-  rename_sort | RenameSpec | optional,
-  add_op | AddOpSpec | optional,
-  drop_op | String | optional,
-  rename_op | RenameSpec | optional,
-  add_equation | EquationSpec | optional,
-  drop_equation | String | optional,
-} in
-
-# -- Rule contracts --
-
-let FeaturePattern = {
-  name | String | optional,
-  type_id | String | optional,
-} in
-
-let Replacement = {
-  name | optional,
-  rename_attrs | { _ : String } | optional,
-  add_attrs | { _ : Dyn } | optional,
-  drop_attrs | Array String | optional,
-  keep_attrs | Array String | optional,
-  map_attr_value | { _ : Dyn } | optional,
-} in
-
-let Rule = {
-  pattern | FeaturePattern,
-  replace | Replacement | optional,
-} in
-
-# -- Compose contracts --
-
-let ComposeMode = std.contract.from_predicate (fun x =>
-  x == "vertical" || x == "horizontal"
-) in
-
-let LensRef =
-  std.contract.from_predicate (fun x =>
-    std.is_record x
-    && (std.record.has_field "ref" x || std.record.has_field "inline" x)
-  )
-in
-
-let ComposeSpec = {
-  mode | ComposeMode,
-  lenses | Array LensRef,
-} in
-
-# -- Auto contracts --
-
-let PreferenceKind = std.contract.from_predicate (fun x =>
-  x == "same_edge_name" || x == "similar_name" || x == "same_kind"
-) in
-
-let PreferencePredicate = {
-  kind | PreferenceKind,
-  threshold | Number | optional,
-} in
-
-let ConstraintType = std.contract.from_predicate (fun x =>
-  x == "scope" || x == "exclude_targets" || x == "exclude_sources" || x == "prefer"
-) in
-
-let Constraint = {
-  type | ConstraintType,
-  under | String | optional,
-  targets | String | optional,
-  vertices | Array String | optional,
-  predicate | PreferencePredicate | optional,
-  weight | Number | optional,
-} in
-
-let HintSpec = {
-  anchors | { _ : String } | optional,
-  constraints | Array Constraint | optional,
-} in
-
-let AutoSpec = {
-  quality_threshold | Number | optional,
-  enable_overlap | Bool | optional,
-  max_search_depth | Number | optional,
-  hints | HintSpec | optional,
-} in
-
-# -- Passthrough --
-
-let Passthrough = std.contract.from_predicate (fun x =>
-  x == "keep" || x == "drop"
-) in
-
-# -- The lens document contract --
-
-let Lens = {
-  id | String,
-  description | String | optional,
-  source | String,
-  target | String,
-
-  steps | Array Step | optional,
-  rules | Array Rule | optional,
-  compose | ComposeSpec | optional,
-  auto | AutoSpec | optional,
-
-  passthrough | Passthrough | optional,
-  invertible | Bool | optional,
-
-  extensions | { _ : Dyn } | optional,
-} in
-
-# =====================================================================
-# Combinator functions
-# =====================================================================
-
-# Remove a field (drop a sort).
-let remove = fun field => { remove_field = field } in
-
-# Rename a field's JSON property key.
-let rename = fun old new => { rename_field = { old = old, new = new } } in
-
-# Add a field with a fallback value.
-let add = fun name kind fallback => {
-  add_field = { name = name, kind = kind, fallback = fallback }
-} in
-
-# Add a field with a computed expression.
-let add_computed = fun name kind fallback expr => {
-  add_field = { name = name, kind = kind, fallback = fallback, expr = expr }
-} in
-
-# Apply an expression to an existing field.
-let apply = fun field expr => {
-  apply_expr = { field = field, expr = expr }
-} in
-
-# Apply an expression with inverse for round-tripping.
-let apply_invertible = fun field expr inverse => {
-  apply_expr = { field = field, expr = expr, inverse = inverse, coercion = iso }
-} in
-
-# Compute a new field from an expression.
-let compute = fun target expr => {
-  compute_field = { target = target, expr = expr }
-} in
-
-# Compute a new field with an inverse expression.
-let compute_invertible = fun target expr inverse => {
-  compute_field = { target = target, expr = expr, inverse = inverse, coercion = iso }
-} in
-
-# Hoist a nested field up one level.
-let hoist = fun parent intermediate child => {
-  hoist_field = { parent = parent, intermediate = intermediate, child = child }
-} in
-
-# Nest a direct child under a new intermediate vertex.
-#
-# Positional args (shorthand): parent, child, intermediate, intermediate_kind, edge_kind.
-# Resulting graph: parent --(intermediate)--> intermediate --(child)--> child
-# with the original parent → child edge dropped.
-#
-# For schemas where the original edge's label differs from the child
-# vertex id (common when vertex ids are path-qualified), build the
-# NestSpec record directly and set `old_edge_name`, `parent_to_intermediate`,
-# and `intermediate_to_child` explicitly.
-let nest = fun parent child intermediate intermediate_kind edge_kind => {
-  nest_field = {
-    parent = parent,
-    child = child,
-    intermediate = intermediate,
-    intermediate_kind = intermediate_kind,
-    edge_kind = edge_kind,
-  }
-} in
-
-# Apply inner steps to each element of an array.
-let map_items = fun focus inner => {
-  scoped = { focus = focus, inner = inner }
-} in
-
-# Pullback along a theory morphism.
-let pullback = fun name domain codomain sort_map op_map => {
-  pullback = {
-    name = name,
-    domain = domain,
-    codomain = codomain,
-    sort_map = sort_map,
-    op_map = op_map,
-  }
-} in
-
-# Coerce a sort's value kind.
-let coerce = fun sort target_kind expr coercion => {
-  coerce_sort = {
-    sort = sort,
-    target_kind = target_kind,
-    expr = expr,
-    coercion = coercion,
-  }
-} in
-
-# Coerce with an inverse.
-let coerce_invertible = fun sort target_kind expr inverse => {
-  coerce_sort = {
-    sort = sort,
-    target_kind = target_kind,
-    expr = expr,
-    inverse = inverse,
-    coercion = iso,
-  }
-} in
-
-# Merge two sorts into one.
-let merge = fun sort_a sort_b merged expr => {
-  merge_sorts = {
-    sort_a = sort_a,
-    sort_b = sort_b,
-    merged = merged,
-    expr = expr,
-  }
-} in
-
-# Add a sort to the theory.
-let add_sort = fun name kind fallback => {
-  add_sort = { name = name, kind = kind, fallback = fallback }
-} in
-
-# Drop a sort from the theory.
-let drop_sort = fun name => { drop_sort = name } in
-
-# Rename a sort.
-let rename_sort = fun old new => { rename_sort = { old = old, new = new } } in
-
-# Add an operation to the theory.
-let add_op = fun name src tgt kind => {
-  add_op = { name = name, src = src, tgt = tgt, kind = kind }
-} in
-
-# Drop an operation from the theory.
-let drop_op = fun name => { drop_op = name } in
-
-# Rename an operation.
-let rename_op = fun old new => { rename_op = { old = old, new = new } } in
-
-# Add an equation.
-let add_equation = fun name lhs rhs => {
-  add_equation = { name = name, lhs = lhs, rhs = rhs }
-} in
-
-# Drop an equation.
-let drop_equation = fun name => { drop_equation = name } in
-
-# -- Hint combinators --
-
-# Build an anchor constraint: source vertex maps to target vertex.
-let anchor = fun src tgt => { "%{src}" = tgt } in
-
-# Build a scope constraint: children of `under` map to children of `targets`.
-let scope = fun under targets => {
-  type = "scope",
-  under = under,
-  targets = targets,
-} in
-
-# Build an exclude_targets constraint.
-let exclude_targets = fun vertices => {
-  type = "exclude_targets",
-  vertices = vertices,
-} in
-
-# Build an exclude_sources constraint.
-let exclude_sources = fun vertices => {
-  type = "exclude_sources",
-  vertices = vertices,
-} in
-
-# Build a prefer constraint with a predicate and weight.
-let prefer_same_edge_name = fun weight => {
-  type = "prefer",
-  predicate = { kind = "same_edge_name" },
-  weight = weight,
-} in
-
-let prefer_similar_name = fun threshold weight => {
-  type = "prefer",
-  predicate = { kind = "similar_name", threshold = threshold },
-  weight = weight,
-} in
-
-# -- Template helpers --
-
-# Generate counter fields (integer fields with default 0).
-let counter_fields = fun fields =>
-  fields |> std.array.map (fun f => add f "integer" 0)
-in
-
-# Generate string fields with empty defaults.
-let string_fields = fun fields =>
-  fields |> std.array.map (fun f => add f "string" "")
-in
-
-# Build a rule mapping one name to another.
-let map_name = fun from to => {
-  pattern = { name = from },
-  replace = { name = to },
-} in
-
-# Build a rule that drops a matched feature.
-let drop_feature = fun name => {
-  pattern = { name = name },
-} in
-
-# =====================================================================
-# Exports
-# =====================================================================
-
 {
-  # Contracts
-  Lens = Lens,
-  Step = Step,
-  Rule = Rule,
-  FeaturePattern = FeaturePattern,
-  Replacement = Replacement,
-  ComposeSpec = ComposeSpec,
-  AutoSpec = AutoSpec,
-  HintSpec = HintSpec,
-  Constraint = Constraint,
-  PreferencePredicate = PreferencePredicate,
-  Coercion = Coercion,
+  # -- Coercion classification --
 
-  # Coercion values
-  iso = iso,
-  retraction = retraction,
-  projection = projection,
-  opaque = opaque,
+  iso = "iso",
+  retraction = "retraction",
+  projection = "projection",
+  opaque = "opaque",
 
-  # Step combinators
-  remove = remove,
-  rename = rename,
-  add = add,
-  add_computed = add_computed,
-  apply = apply,
-  apply_invertible = apply_invertible,
-  compute = compute,
-  compute_invertible = compute_invertible,
-  hoist = hoist,
-  nest = nest,
-  map_items = map_items,
-  pullback = pullback,
-  coerce = coerce,
-  coerce_invertible = coerce_invertible,
-  merge = merge,
-  add_sort = add_sort,
-  drop_sort = drop_sort,
-  rename_sort = rename_sort,
-  add_op = add_op,
-  drop_op = drop_op,
-  rename_op = rename_op,
-  add_equation = add_equation,
-  drop_equation = drop_equation,
+  Coercion = std.contract.from_predicate (fun x =>
+    x == "iso" || x == "retraction" || x == "projection" || x == "opaque"
+  ),
 
-  # Hint combinators
-  anchor = anchor,
-  scope = scope,
-  exclude_targets = exclude_targets,
-  exclude_sources = exclude_sources,
-  prefer_same_edge_name = prefer_same_edge_name,
-  prefer_similar_name = prefer_similar_name,
+  # -- Step contracts --
 
-  # Template helpers
-  counter_fields = counter_fields,
-  string_fields = string_fields,
-  map_name = map_name,
-  drop_feature = drop_feature,
+  RenameSpec = {
+    old | String,
+    new | String,
+  },
+
+  AddFieldSpec = {
+    name | String,
+    kind | String,
+    fallback | optional,
+    expr | String | optional,
+  },
+
+  ApplyExprSpec = {
+    field | String,
+    expr | String,
+    inverse | String | optional,
+    coercion | Coercion | optional,
+  },
+
+  ComputeFieldSpec = {
+    target | String,
+    expr | String,
+    inverse | String | optional,
+    coercion | Coercion | optional,
+  },
+
+  HoistSpec = {
+    parent | String,
+    intermediate | String,
+    child | String,
+  },
+
+  NestSpec = {
+    parent | String,
+    child | String,
+    intermediate | String,
+    intermediate_kind | String,
+    edge_kind | String,
+    old_edge_name | String | optional,
+    parent_to_intermediate | String | optional,
+    intermediate_to_child | String | optional,
+  },
+
+  PullbackSpec = {
+    name | String,
+    domain | String,
+    codomain | String,
+    sort_map | { _ : String } | optional,
+    op_map | { _ : String } | optional,
+  },
+
+  CoerceSortSpec = {
+    sort | String,
+    target_kind | String,
+    expr | String,
+    inverse | String | optional,
+    coercion | Coercion,
+  },
+
+  MergeSortsSpec = {
+    sort_a | String,
+    sort_b | String,
+    merged | String,
+    expr | String,
+  },
+
+  AddSortSpec = {
+    name | String,
+    kind | String,
+    fallback | optional,
+  },
+
+  AddOpSpec = {
+    name | String,
+    src | String,
+    tgt | String,
+    kind | String,
+  },
+
+  EquationSpec = {
+    name | String,
+    lhs | String,
+    rhs | String,
+  },
+
+  Step = {
+    remove_field | String | optional,
+    rename_field | RenameSpec | optional,
+    add_field | AddFieldSpec | optional,
+    apply_expr | ApplyExprSpec | optional,
+    compute_field | ComputeFieldSpec | optional,
+    hoist_field | HoistSpec | optional,
+    nest_field | NestSpec | optional,
+    scoped | { focus | String, inner | Array Dyn } | optional,
+    pullback | PullbackSpec | optional,
+    coerce_sort | CoerceSortSpec | optional,
+    merge_sorts | MergeSortsSpec | optional,
+    add_sort | AddSortSpec | optional,
+    drop_sort | String | optional,
+    rename_sort | RenameSpec | optional,
+    add_op | AddOpSpec | optional,
+    drop_op | String | optional,
+    rename_op | RenameSpec | optional,
+    add_equation | EquationSpec | optional,
+    drop_equation | String | optional,
+  },
+
+  # -- Rule contracts --
+
+  FeaturePattern = {
+    name | String | optional,
+    type_id | String | optional,
+  },
+
+  Replacement = {
+    name | optional,
+    rename_attrs | { _ : String } | optional,
+    add_attrs | { _ : Dyn } | optional,
+    drop_attrs | Array String | optional,
+    keep_attrs | Array String | optional,
+    map_attr_value | { _ : Dyn } | optional,
+  },
+
+  Rule = {
+    pattern | FeaturePattern,
+    replace | Replacement | optional,
+  },
+
+  # -- Compose contracts --
+
+  ComposeMode = std.contract.from_predicate (fun x =>
+    x == "vertical" || x == "horizontal"
+  ),
+
+  LensRef =
+    std.contract.from_predicate (fun x =>
+      std.is_record x
+      && (std.record.has_field "ref" x || std.record.has_field "inline" x)
+    ),
+
+  ComposeSpec = {
+    mode | ComposeMode,
+    lenses | Array LensRef,
+  },
+
+  # -- Auto contracts --
+
+  PreferenceKind = std.contract.from_predicate (fun x =>
+    x == "same_edge_name" || x == "similar_name" || x == "same_kind"
+  ),
+
+  PreferencePredicate = {
+    kind | PreferenceKind,
+    threshold | Number | optional,
+  },
+
+  ConstraintType = std.contract.from_predicate (fun x =>
+    x == "scope" || x == "exclude_targets" || x == "exclude_sources" || x == "prefer"
+  ),
+
+  Constraint = {
+    type | ConstraintType,
+    under | String | optional,
+    targets | String | optional,
+    vertices | Array String | optional,
+    predicate | PreferencePredicate | optional,
+    weight | Number | optional,
+  },
+
+  HintSpec = {
+    anchors | { _ : String } | optional,
+    constraints | Array Constraint | optional,
+  },
+
+  AutoSpec = {
+    quality_threshold | Number | optional,
+    enable_overlap | Bool | optional,
+    max_search_depth | Number | optional,
+    hints | HintSpec | optional,
+  },
+
+  # -- Passthrough --
+
+  Passthrough = std.contract.from_predicate (fun x =>
+    x == "keep" || x == "drop"
+  ),
+
+  # -- The lens document contract --
+
+  Lens = {
+    id | String,
+    description | String | optional,
+    source | String,
+    target | String,
+
+    steps | Array Step | optional,
+    rules | Array Rule | optional,
+    compose | ComposeSpec | optional,
+    auto | AutoSpec | optional,
+
+    passthrough | Passthrough | optional,
+    invertible | Bool | optional,
+
+    extensions | { _ : Dyn } | optional,
+  },
+
+  # =====================================================================
+  # Combinator functions
+  #
+  # Parameter names use a _ prefix to avoid colliding with the record
+  # field names they populate (Nickel's record scope shadows enclosing
+  # bindings when the names coincide, causing infinite recursion).
+  # =====================================================================
+
+  remove = fun _field => { remove_field = _field },
+
+  rename = fun _old _new => { rename_field = { old = _old, new = _new } },
+
+  add = fun _name _kind _fallback => {
+    add_field = { name = _name, kind = _kind, fallback = _fallback }
+  },
+
+  add_computed = fun _name _kind _fallback _expr => {
+    add_field = { name = _name, kind = _kind, fallback = _fallback, expr = _expr }
+  },
+
+  apply = fun _field _expr => {
+    apply_expr = { field = _field, expr = _expr }
+  },
+
+  apply_invertible = fun _field _expr _inverse => {
+    apply_expr = { field = _field, expr = _expr, inverse = _inverse, coercion = "iso" }
+  },
+
+  compute = fun _target _expr => {
+    compute_field = { target = _target, expr = _expr }
+  },
+
+  compute_invertible = fun _target _expr _inverse => {
+    compute_field = { target = _target, expr = _expr, inverse = _inverse, coercion = "iso" }
+  },
+
+  hoist = fun _parent _intermediate _child => {
+    hoist_field = { parent = _parent, intermediate = _intermediate, child = _child }
+  },
+
+  nest = fun _parent _child _intermediate _intermediate_kind _edge_kind => {
+    nest_field = {
+      parent = _parent,
+      child = _child,
+      intermediate = _intermediate,
+      intermediate_kind = _intermediate_kind,
+      edge_kind = _edge_kind,
+    }
+  },
+
+  map_items = fun _focus _inner => {
+    scoped = { focus = _focus, inner = _inner }
+  },
+
+  pullback = fun _name _domain _codomain _sort_map _op_map => {
+    pullback = {
+      name = _name,
+      domain = _domain,
+      codomain = _codomain,
+      sort_map = _sort_map,
+      op_map = _op_map,
+    }
+  },
+
+  coerce = fun _sort _target_kind _expr _coercion => {
+    coerce_sort = {
+      sort = _sort,
+      target_kind = _target_kind,
+      expr = _expr,
+      coercion = _coercion,
+    }
+  },
+
+  coerce_invertible = fun _sort _target_kind _expr _inverse => {
+    coerce_sort = {
+      sort = _sort,
+      target_kind = _target_kind,
+      expr = _expr,
+      inverse = _inverse,
+      coercion = "iso",
+    }
+  },
+
+  merge = fun _sort_a _sort_b _merged _expr => {
+    merge_sorts = {
+      sort_a = _sort_a,
+      sort_b = _sort_b,
+      merged = _merged,
+      expr = _expr,
+    }
+  },
+
+  add_sort = fun _name _kind _fallback => {
+    add_sort = { name = _name, kind = _kind, fallback = _fallback }
+  },
+
+  drop_sort = fun _name => { drop_sort = _name },
+
+  rename_sort = fun _old _new => { rename_sort = { old = _old, new = _new } },
+
+  add_op = fun _name _src _tgt _kind => {
+    add_op = { name = _name, src = _src, tgt = _tgt, kind = _kind }
+  },
+
+  drop_op = fun _name => { drop_op = _name },
+
+  rename_op = fun _old _new => { rename_op = { old = _old, new = _new } },
+
+  add_equation = fun _name _lhs _rhs => {
+    add_equation = { name = _name, lhs = _lhs, rhs = _rhs }
+  },
+
+  drop_equation = fun _name => { drop_equation = _name },
+
+  # -- Hint combinators --
+
+  anchor = fun _src _tgt => { "%{_src}" = _tgt },
+
+  scope = fun _under _targets => {
+    type = "scope",
+    under = _under,
+    targets = _targets,
+  },
+
+  exclude_targets = fun _vertices => {
+    type = "exclude_targets",
+    vertices = _vertices,
+  },
+
+  exclude_sources = fun _vertices => {
+    type = "exclude_sources",
+    vertices = _vertices,
+  },
+
+  prefer_same_edge_name = fun _weight => {
+    type = "prefer",
+    predicate = { kind = "same_edge_name" },
+    weight = _weight,
+  },
+
+  prefer_similar_name = fun _threshold _weight => {
+    type = "prefer",
+    predicate = { kind = "similar_name", threshold = _threshold },
+    weight = _weight,
+  },
+
+  # -- Template helpers --
+
+  counter_fields = fun _fields =>
+    _fields |> std.array.map (fun _f => { add_field = { name = _f, kind = "integer", fallback = 0 } }),
+
+  string_fields = fun _fields =>
+    _fields |> std.array.map (fun _f => { add_field = { name = _f, kind = "string", fallback = "" } }),
+
+  map_name = fun _from _to => {
+    pattern = { name = _from },
+    replace = { name = _to },
+  },
+
+  drop_feature = fun _name => {
+    pattern = { name = _name },
+  },
 }

--- a/crates/panproto-lens-dsl/tests/nickel_contract.rs
+++ b/crates/panproto-lens-dsl/tests/nickel_contract.rs
@@ -1,0 +1,165 @@
+//! Regression tests for the bundled lens.ncl Nickel contract module.
+//!
+//! These tests exercise the full Nickel evaluation path to catch
+//! reserved-word collisions (#144), missing-definition errors (#151),
+//! and infinite-recursion regressions (#154) before they ship.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use panproto_lens_dsl::eval::eval_nickel;
+
+fn with_big_stack<F: FnOnce() + Send + 'static>(inner: F) {
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(inner)
+        .expect("spawn")
+        .join()
+        .expect("worker panicked");
+}
+
+#[test]
+fn nickel_rename_step_round_trips() {
+    let ncl = r#"
+let L = import "panproto/lens.ncl" in
+{
+  id = "test-rename",
+  source = "src",
+  target = "tgt",
+  steps = [L.rename "old_field" "new_field"],
+} | L.Lens
+"#;
+    let doc = eval_nickel(ncl, &[]).expect("rename step should evaluate");
+    assert_eq!(doc.id, "test-rename");
+    assert_eq!(doc.steps.as_ref().map_or(0, Vec::len), 1);
+}
+
+#[test]
+fn nickel_add_step_with_fallback() {
+    let ncl = r#"
+let L = import "panproto/lens.ncl" in
+{
+  id = "test-add",
+  source = "s",
+  target = "t",
+  steps = [L.add "count" "integer" 0],
+} | L.Lens
+"#;
+    let doc = eval_nickel(ncl, &[]).expect("add step with fallback should evaluate");
+    assert_eq!(doc.id, "test-add");
+    assert_eq!(doc.steps.as_ref().map_or(0, Vec::len), 1);
+}
+
+#[test]
+fn nickel_remove_step() {
+    let ncl = r#"
+let L = import "panproto/lens.ncl" in
+{
+  id = "test-remove",
+  source = "s",
+  target = "t",
+  steps = [L.remove "old_field"],
+} | L.Lens
+"#;
+    let doc = eval_nickel(ncl, &[]).expect("remove step should evaluate");
+    assert_eq!(doc.steps.as_ref().map_or(0, Vec::len), 1);
+}
+
+#[test]
+fn nickel_rule_with_pattern() {
+    let ncl = r#"
+let L = import "panproto/lens.ncl" in
+{
+  id = "test-rules",
+  source = "s",
+  target = "t",
+  rules = [L.map_name "old" "new", L.drop_feature "obsolete"],
+} | L.Lens
+"#;
+    let doc = eval_nickel(ncl, &[]).expect("rules with pattern/replace should evaluate");
+    assert_eq!(doc.rules.as_ref().map_or(0, Vec::len), 2);
+}
+
+#[test]
+fn nickel_multiple_combinators() {
+    let ncl = r#"
+let L = import "panproto/lens.ncl" in
+{
+  id = "multi",
+  source = "s",
+  target = "t",
+  steps = [
+    L.rename "a" "b",
+    L.remove "c",
+    L.add "d" "string" "",
+    L.hoist "parent" "mid" "child",
+    L.compute "x" "y + 1",
+    L.apply "z" "z * 2",
+  ],
+} | L.Lens
+"#;
+    let doc = eval_nickel(ncl, &[]).expect("multiple combinators should evaluate");
+    assert_eq!(doc.steps.as_ref().map_or(0, Vec::len), 6);
+}
+
+#[test]
+fn nickel_all_exports_accessible() {
+    with_big_stack(|| {
+        let ncl = r#"
+let L = import "panproto/lens.ncl" in
+let _ = L.Lens in
+let _ = L.Step in
+let _ = L.Rule in
+let _ = L.FeaturePattern in
+let _ = L.Replacement in
+let _ = L.ComposeSpec in
+let _ = L.AutoSpec in
+let _ = L.HintSpec in
+let _ = L.Constraint in
+let _ = L.Coercion in
+let _ = L.iso in
+let _ = L.retraction in
+let _ = L.projection in
+let _ = L.opaque in
+let _ = L.remove in
+let _ = L.rename in
+let _ = L.add in
+let _ = L.add_computed in
+let _ = L.apply in
+let _ = L.apply_invertible in
+let _ = L.compute in
+let _ = L.compute_invertible in
+let _ = L.hoist in
+let _ = L.nest in
+let _ = L.map_items in
+let _ = L.pullback in
+let _ = L.coerce in
+let _ = L.coerce_invertible in
+let _ = L.merge in
+let _ = L.add_sort in
+let _ = L.drop_sort in
+let _ = L.rename_sort in
+let _ = L.add_op in
+let _ = L.drop_op in
+let _ = L.rename_op in
+let _ = L.add_equation in
+let _ = L.drop_equation in
+let _ = L.anchor in
+let _ = L.scope in
+let _ = L.exclude_targets in
+let _ = L.exclude_sources in
+let _ = L.prefer_same_edge_name in
+let _ = L.prefer_similar_name in
+let _ = L.counter_fields in
+let _ = L.string_fields in
+let _ = L.map_name in
+let _ = L.drop_feature in
+{
+  id = "export-check",
+  source = "s",
+  target = "t",
+  steps = [],
+} | L.Lens
+"#;
+        eval_nickel(ncl, &[]).expect("all contract exports should be accessible");
+    });
+}

--- a/crates/panproto-parse/src/emit_pretty.rs
+++ b/crates/panproto-parse/src/emit_pretty.rs
@@ -728,6 +728,20 @@ fn emit_vertex(
         // may record trailing comments as children of the surrounding
         // vertex (i.e. after the last structural child the rule matched).
         drain_extras(protocol, schema, grammar, &mut cursor, out)?;
+        // Emit remaining unconsumed structural children that the grammar
+        // rule did not match. This covers cases where tree-sitter's parser
+        // produces child kinds not reachable from grammar.json's production
+        // rules (e.g. Julia's macrocall_expression can have an
+        // `argument_list` child even though the grammar only references
+        // `macro_argument_list`).
+        for (i, edge) in cursor.edges.iter().enumerate() {
+            if !cursor.consumed[i] {
+                let child_kind = schema.vertices.get(&edge.tgt).map(|v| v.kind.as_ref());
+                if child_kind.is_some_and(|k| !grammar.extras.contains(k)) {
+                    emit_vertex(protocol, schema, grammar, &edge.tgt, out)?;
+                }
+            }
+        }
         return Ok(());
     }
 
@@ -1062,6 +1076,8 @@ fn emit_production_inner(
                         || name.ends_with("_or_eof")
                     {
                         out.newline();
+                    } else if name.contains("semicolon") {
+                        out.token(";");
                     }
                     Ok(())
                 }
@@ -2363,7 +2379,7 @@ fn first_is_operand_start(s: &str) -> bool {
 }
 
 fn is_punct_open(s: &str) -> bool {
-    matches!(s, "(" | "[" | "{" | "\"" | "'" | "`")
+    matches!(s, "(" | "[" | "{" | "\"" | "'" | "`" | "@" | "#")
 }
 
 fn is_punct_close(s: &str) -> bool {

--- a/crates/panproto-parse/tests/emit_pretty_js_semicolons.rs
+++ b/crates/panproto-parse/tests/emit_pretty_js_semicolons.rs
@@ -1,0 +1,82 @@
+//! Regression test for JavaScript automatic semicolon insertion (#155).
+//!
+//! Verifies that `emit_pretty` inserts semicolons between sibling
+//! statements in a `statement_block`, producing output that JavaScript's
+//! parser can re-parse without ERROR nodes.
+
+#![cfg(feature = "grammars")]
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use panproto_parse::ParserRegistry;
+use panproto_schema::Schema;
+
+fn registry() -> ParserRegistry {
+    ParserRegistry::new()
+}
+
+fn strip_byte_fragments(schema: &mut Schema) {
+    for constraints in schema.constraints.values_mut() {
+        constraints.retain(|c| {
+            let s = c.sort.as_ref();
+            !(s == "start-byte" || s == "end-byte" || s.starts_with("interstitial-"))
+        });
+    }
+}
+
+fn with_big_stack<F: FnOnce() + Send + 'static>(inner: F) {
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(inner)
+        .expect("spawn")
+        .join()
+        .expect("worker panicked");
+}
+
+#[test]
+fn js_statement_block_has_semicolons() {
+    with_big_stack(|| {
+        let reg = registry();
+        let src = b"function model(y){\n  var theta = sample(Beta(2, 2));\n  observe(Bernoulli(theta), y);\n}\n";
+        let mut schema = reg
+            .parse_with_protocol("javascript", src, "m.js")
+            .expect("parse");
+        strip_byte_fragments(&mut schema);
+        let emitted = reg
+            .emit_pretty_with_protocol("javascript", &schema)
+            .expect("emit_pretty");
+        let text = std::str::from_utf8(&emitted).unwrap();
+        assert!(
+            text.contains(';'),
+            "emitted JavaScript must contain semicolons, got: {text}"
+        );
+    });
+}
+
+#[test]
+fn js_round_trip_no_error_nodes() {
+    with_big_stack(|| {
+        let reg = registry();
+        let src = b"function f(){\n  var x = 1;\n  var y = 2;\n  return x + y;\n}\n";
+        let mut schema = reg
+            .parse_with_protocol("javascript", src, "f.js")
+            .expect("parse");
+        strip_byte_fragments(&mut schema);
+        let emitted = reg
+            .emit_pretty_with_protocol("javascript", &schema)
+            .expect("emit_pretty");
+        let reparsed = reg
+            .parse_with_protocol("javascript", &emitted, "rt.js")
+            .expect("reparse");
+        let error_count = reparsed
+            .vertices
+            .values()
+            .filter(|v| v.kind.as_ref() == "ERROR")
+            .count();
+        assert_eq!(
+            error_count,
+            0,
+            "re-parsed JavaScript should have 0 ERROR nodes, got {error_count}\nemitted:\n{}",
+            std::str::from_utf8(&emitted).unwrap_or("<non-utf8>")
+        );
+    });
+}

--- a/crates/panproto-parse/tests/emit_pretty_julia_macrocall.rs
+++ b/crates/panproto-parse/tests/emit_pretty_julia_macrocall.rs
@@ -1,0 +1,109 @@
+//! Regression tests for Julia macrocall `emit_pretty` (#150, #153).
+//!
+//! Verifies that both long-form (`@model function ... end`) and
+//! short-form (`@trace(args)`) macrocall expressions round-trip
+//! through `emit_pretty` without dropping the body or arguments.
+
+#![cfg(all(feature = "grammars", feature = "lang-julia"))]
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use panproto_parse::ParserRegistry;
+use panproto_schema::Schema;
+
+fn registry() -> ParserRegistry {
+    ParserRegistry::new()
+}
+
+fn strip_byte_fragments(schema: &mut Schema) {
+    for constraints in schema.constraints.values_mut() {
+        constraints.retain(|c| {
+            let s = c.sort.as_ref();
+            !(s == "start-byte" || s == "end-byte" || s.starts_with("interstitial-"))
+        });
+    }
+}
+
+fn with_big_stack<F: FnOnce() + Send + 'static>(inner: F) {
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(inner)
+        .expect("spawn")
+        .join()
+        .expect("worker panicked");
+}
+
+#[test]
+fn julia_macrocall_long_form_preserves_body() {
+    with_big_stack(|| {
+        let reg = registry();
+        let src = b"@model function model(y)\n    theta ~ Beta(2, 2)\nend\n";
+        let mut schema = reg
+            .parse_with_protocol("julia", src, "m.jl")
+            .expect("parse");
+        strip_byte_fragments(&mut schema);
+        let emitted = reg
+            .emit_pretty_with_protocol("julia", &schema)
+            .expect("emit_pretty");
+        let text = std::str::from_utf8(&emitted).unwrap();
+        assert!(
+            text.contains("function"),
+            "long-form macrocall body must contain 'function', got: {text}"
+        );
+        assert!(
+            text.contains("Beta"),
+            "long-form macrocall body must contain 'Beta', got: {text}"
+        );
+        assert!(
+            !text.starts_with("."),
+            "macrocall must not start with '.', got: {text}"
+        );
+    });
+}
+
+#[test]
+fn julia_macrocall_short_form_preserves_args() {
+    with_big_stack(|| {
+        let reg = registry();
+        let src = b"@trace(beta(2, 2), :theta)\n";
+        let mut schema = reg
+            .parse_with_protocol("julia", src, "x.jl")
+            .expect("parse");
+        strip_byte_fragments(&mut schema);
+        let emitted = reg
+            .emit_pretty_with_protocol("julia", &schema)
+            .expect("emit_pretty");
+        let text = std::str::from_utf8(&emitted).unwrap();
+        assert!(
+            text.contains("beta"),
+            "short-form macrocall must contain 'beta', got: {text}"
+        );
+        assert!(
+            text.contains("theta"),
+            "short-form macrocall must contain 'theta', got: {text}"
+        );
+    });
+}
+
+#[test]
+fn julia_macro_identifier_no_space_after_at() {
+    with_big_stack(|| {
+        let reg = registry();
+        let src = b"@model function m()\nend\n";
+        let mut schema = reg
+            .parse_with_protocol("julia", src, "m.jl")
+            .expect("parse");
+        strip_byte_fragments(&mut schema);
+        let emitted = reg
+            .emit_pretty_with_protocol("julia", &schema)
+            .expect("emit_pretty");
+        let text = std::str::from_utf8(&emitted).unwrap();
+        assert!(
+            text.contains("@model") || text.contains("@m"),
+            "@ must be tight against identifier (no space), got: {text}"
+        );
+        assert!(
+            !text.contains("@ "),
+            "@ must not be followed by a space, got: {text}"
+        );
+    });
+}

--- a/crates/panproto-theory-dsl/contracts/theory.ncl
+++ b/crates/panproto-theory-dsl/contracts/theory.ncl
@@ -7,319 +7,260 @@
 #   let { Theory, Morphism, Sort, Op, simple, unary, eq, colimit, .. }
 #     = import "panproto/theory.ncl" in
 #   { id = "dev.my-domain.my-theory", description = "...", ... }
-
-# ═══════════════════════════════════════════════════════════════════
-# Sort kind constructors
-# ═══════════════════════════════════════════════════════════════════
-
-let Structural = { type = "structural" } in
-let Val = fun kind => { type = "val", value_kind = kind } in
-let Coercion = fun from to class => {
-  type = "coercion", from = from, to = to, class = class
-} in
-let Merger = fun kind => { type = "merger", value_kind = kind } in
-
-# ═══════════════════════════════════════════════════════════════════
-# Contracts
-# ═══════════════════════════════════════════════════════════════════
-
-let ParamSpec = {
-  name | String,
-  sort | String,
-  implicit | Bool | optional,
-} in
-
-let SortKindSpec = {
-  type | String,
-  ..
-} in
-
-let SortSpec = {
-  name | String,
-  params | Array ParamSpec | default = [],
-  kind | default = Structural,
-} in
-
-let OpSpec = {
-  name | String,
-  input | String | optional,
-  inputs | Array ParamSpec | optional,
-  output | String,
-} in
-
-let EquationSpec = {
-  name | String,
-  lhs | String,
-  rhs | String,
-} in
-
-let DirectedEqSpec = {
-  name | String,
-  lhs | String,
-  rhs | String,
-  impl_expr | String,
-  inverse | String | optional,
-  source_kind | String | optional,
-  target_kind | String | optional,
-  coercion_class | String | default = "iso",
-} in
-
-let StrategySpec = {
-  type | String,
-  ..
-} in
-
-let PolicySpec = {
-  name | String,
-  value_kind | String,
-  strategy | StrategySpec,
-} in
-
-let EdgeRuleSpec = {
-  edge_kind | String,
-  src_kind | String,
-  tgt_kind | String,
-} in
-
-let ColimitStepSpec = {
-  left | String,
-  right | String,
-  shared_sorts | Array String,
-  shared_ops | Array String | default = [],
-} in
-
-# ═══════════════════════════════════════════════════════════════════
-# Document contracts
-# ═══════════════════════════════════════════════════════════════════
-
-let Theory = {
-  id | String,
-  description | String,
-  theory | String,
-  extends | Array String | default = [],
-  sorts | Array SortSpec | default = [],
-  ops | Array OpSpec | default = [],
-  equations | Array EquationSpec | default = [],
-  directed_equations | Array DirectedEqSpec | default = [],
-  policies | Array PolicySpec | default = [],
-} in
-
-let Morphism = {
-  id | String,
-  description | String,
-  morphism | String,
-  domain | String,
-  codomain | String,
-  sort_map | { _ : String },
-  op_map | { _ : String },
-} in
-
-let Composition = {
-  id | String,
-  description | String,
-  compose | {
-    result | String,
-    bases | Array String | default = [],
-    steps | Array ColimitStepSpec,
-  },
-} in
-
-let Protocol = {
-  id | String,
-  description | String,
-  protocol | String,
-  schema_theory | String | { theory | String, .. } | { result | String, .. },
-  instance_theory | String | { theory | String, .. } | { result | String, .. },
-  edge_rules | Array EdgeRuleSpec | default = [],
-} in
-
-let Bundle = {
-  id | String,
-  description | String,
-  bundle | String,
-  theories | Array { theory | String, .. } | default = [],
-  morphisms | Array { morphism | String, .. } | default = [],
-  compositions | Array { result | String, .. } | default = [],
-  protocols | Array { protocol | String, .. } | default = [],
-} in
-
-let Class = {
-  id | String,
-  description | String,
-  class | String,
-  params | Array String,
-  signatures | Array OpSpec,
-  axioms | Array EquationSpec | default = [],
-} in
-
-let Instance = {
-  id | String,
-  description | String,
-  instance | String,
-  class | String,
-  target | String,
-  bindings | { _ : String },
-} in
-
-# ═══════════════════════════════════════════════════════════════════
-# Sort combinators
-# ═══════════════════════════════════════════════════════════════════
-
-let simple = fun name => { name = name } in
-let dependent = fun name params => { name = name, params = params } in
-let val_sort = fun name kind => { name = name, kind = Val kind } in
-let coercion_sort = fun name from to class => {
-  name = name, kind = Coercion from to class
-} in
-let merger_sort = fun name kind => { name = name, kind = Merger kind } in
-let param = fun name sort => { name = name, sort = sort } in
-
-# ═══════════════════════════════════════════════════════════════════
-# Operation combinators
-# ═══════════════════════════════════════════════════════════════════
-
-let unary = fun name input output => {
-  name = name, input = input, output = output,
-} in
-
-let binary = fun name in1 in2 output => {
-  name = name,
-  inputs = [param in1.0 in1.1, param in2.0 in2.1],
-  output = output,
-} in
-
-let nullary = fun name output => {
-  name = name, inputs = [], output = output,
-} in
-
-let nary = fun name inputs output => {
-  name = name, inputs = inputs, output = output,
-} in
-
-# ═══════════════════════════════════════════════════════════════════
-# Equation combinators
-# ═══════════════════════════════════════════════════════════════════
-
-let eq = fun name lhs rhs => {
-  name = name, lhs = lhs, rhs = rhs,
-} in
-
-let directed_eq = fun name lhs rhs impl_expr => {
-  name = name, lhs = lhs, rhs = rhs, impl_expr = impl_expr,
-} in
-
-let directed_eq_invertible = fun name lhs rhs impl_expr inverse => {
-  name = name, lhs = lhs, rhs = rhs,
-  impl_expr = impl_expr, inverse = inverse,
-} in
-
-# ═══════════════════════════════════════════════════════════════════
-# Policy combinators
-# ═══════════════════════════════════════════════════════════════════
-
-let keep_left = fun name value_kind => {
-  name = name, value_kind = value_kind,
-  strategy = { type = "keep_left" },
-} in
-
-let keep_right = fun name value_kind => {
-  name = name, value_kind = value_kind,
-  strategy = { type = "keep_right" },
-} in
-
-let fail_on_conflict = fun name value_kind => {
-  name = name, value_kind = value_kind,
-  strategy = { type = "fail" },
-} in
-
-let custom_policy = fun name value_kind expr => {
-  name = name, value_kind = value_kind,
-  strategy = { type = "custom", expr = expr },
-} in
-
-# ═══════════════════════════════════════════════════════════════════
-# Composition combinators
-# ═══════════════════════════════════════════════════════════════════
-
-let colimit = fun left right shared_sorts => {
-  left = left, right = right,
-  shared_sorts = shared_sorts, shared_ops = [],
-} in
-
-let colimit_with_ops = fun left right shared_sorts shared_ops => {
-  left = left, right = right,
-  shared_sorts = shared_sorts, shared_ops = shared_ops,
-} in
-
-# ═══════════════════════════════════════════════════════════════════
-# Edge rule combinators
-# ═══════════════════════════════════════════════════════════════════
-
-let edge_rule = fun edge_kind src_kind tgt_kind => {
-  edge_kind = edge_kind, src_kind = src_kind, tgt_kind = tgt_kind,
-} in
-
-# ═══════════════════════════════════════════════════════════════════
-# Exports
-# ═══════════════════════════════════════════════════════════════════
+#
+# Parameter names use a _ prefix to avoid colliding with the record
+# field names they populate (Nickel's record scope shadows enclosing
+# bindings when the names coincide, causing infinite recursion).
 
 {
+  # ═══════════════════════════════════════════════════════════════════
   # Sort kind constructors
-  Structural = Structural,
-  Val = Val,
-  Coercion = Coercion,
-  Merger = Merger,
+  # ═══════════════════════════════════════════════════════════════════
 
+  Structural = { type = "structural" },
+  Val = fun _kind => { type = "val", value_kind = _kind },
+  Coercion = fun _from _to _class => {
+    type = "coercion", from = _from, to = _to, class = _class
+  },
+  Merger = fun _kind => { type = "merger", value_kind = _kind },
+
+  # ═══════════════════════════════════════════════════════════════════
   # Contracts
-  ParamSpec = ParamSpec,
-  SortKindSpec = SortKindSpec,
-  SortSpec = SortSpec,
-  OpSpec = OpSpec,
-  EquationSpec = EquationSpec,
-  DirectedEqSpec = DirectedEqSpec,
-  StrategySpec = StrategySpec,
-  PolicySpec = PolicySpec,
-  EdgeRuleSpec = EdgeRuleSpec,
-  ColimitStepSpec = ColimitStepSpec,
+  # ═══════════════════════════════════════════════════════════════════
 
+  ParamSpec = {
+    name | String,
+    sort | String,
+    implicit | Bool | optional,
+  },
+
+  SortKindSpec = {
+    type | String,
+    ..
+  },
+
+  SortSpec = {
+    name | String,
+    params | Array ParamSpec | optional,
+    kind | optional,
+  },
+
+  OpSpec = {
+    name | String,
+    input | String | optional,
+    inputs | Array ParamSpec | optional,
+    output | String,
+  },
+
+  EquationSpec = {
+    name | String,
+    lhs | String,
+    rhs | String,
+  },
+
+  DirectedEqSpec = {
+    name | String,
+    lhs | String,
+    rhs | String,
+    impl_expr | String,
+    inverse | String | optional,
+    source_kind | String | optional,
+    target_kind | String | optional,
+    coercion_class | String | optional,
+  },
+
+  StrategySpec = {
+    type | String,
+    ..
+  },
+
+  PolicySpec = {
+    name | String,
+    value_kind | String,
+    strategy | StrategySpec,
+  },
+
+  EdgeRuleSpec = {
+    edge_kind | String,
+    src_kind | String,
+    tgt_kind | String,
+  },
+
+  ColimitStepSpec = {
+    left | String,
+    right | String,
+    shared_sorts | Array String,
+    shared_ops | Array String | optional,
+  },
+
+  # ═══════════════════════════════════════════════════════════════════
   # Document contracts
-  Theory = Theory,
-  Morphism = Morphism,
-  Composition = Composition,
-  Protocol = Protocol,
-  Bundle = Bundle,
-  Class = Class,
-  Instance = Instance,
+  # ═══════════════════════════════════════════════════════════════════
 
+  Theory = {
+    id | String,
+    description | String,
+    theory | String,
+    extends | Array String | optional,
+    sorts | Array SortSpec | optional,
+    ops | Array OpSpec | optional,
+    equations | Array EquationSpec | optional,
+    directed_equations | Array DirectedEqSpec | optional,
+    policies | Array PolicySpec | optional,
+  },
+
+  Morphism = {
+    id | String,
+    description | String,
+    morphism | String,
+    domain | String,
+    codomain | String,
+    sort_map | { _ : String },
+    op_map | { _ : String },
+  },
+
+  Composition = {
+    id | String,
+    description | String,
+    compose | {
+      result | String,
+      bases | Array String | optional,
+      steps | Array ColimitStepSpec,
+    },
+  },
+
+  Protocol = {
+    id | String,
+    description | String,
+    protocol | String,
+    schema_theory | String | { theory | String, .. } | { result | String, .. },
+    instance_theory | String | { theory | String, .. } | { result | String, .. },
+    edge_rules | Array EdgeRuleSpec | optional,
+  },
+
+  Bundle = {
+    id | String,
+    description | String,
+    bundle | String,
+    theories | Array { theory | String, .. } | optional,
+    morphisms | Array { morphism | String, .. } | optional,
+    compositions | Array { result | String, .. } | optional,
+    protocols | Array { protocol | String, .. } | optional,
+  },
+
+  Class = {
+    id | String,
+    description | String,
+    class | String,
+    params | Array String,
+    signatures | Array OpSpec,
+    axioms | Array EquationSpec | optional,
+  },
+
+  Instance = {
+    id | String,
+    description | String,
+    instance | String,
+    class | String,
+    target | String,
+    bindings | { _ : String },
+  },
+
+  # ═══════════════════════════════════════════════════════════════════
   # Sort combinators
-  simple = simple,
-  dependent = dependent,
-  val_sort = val_sort,
-  coercion_sort = coercion_sort,
-  merger_sort = merger_sort,
-  param = param,
+  # ═══════════════════════════════════════════════════════════════════
 
+  simple = fun _name => { name = _name },
+  dependent = fun _name _params => { name = _name, params = _params },
+  val_sort = fun _name _kind => { name = _name, kind = Val _kind },
+  coercion_sort = fun _name _from _to _class => {
+    name = _name, kind = Coercion _from _to _class
+  },
+  merger_sort = fun _name _kind => { name = _name, kind = Merger _kind },
+  param = fun _name _sort => { name = _name, sort = _sort },
+
+  # ═══════════════════════════════════════════════════════════════════
   # Operation combinators
-  unary = unary,
-  binary = binary,
-  nullary = nullary,
-  nary = nary,
+  # ═══════════════════════════════════════════════════════════════════
 
+  unary = fun _name _input _output => {
+    name = _name, input = _input, output = _output,
+  },
+
+  binary = fun _name _in1 _in2 _output => {
+    name = _name,
+    inputs = [{ name = _in1.0, sort = _in1.1 }, { name = _in2.0, sort = _in2.1 }],
+    output = _output,
+  },
+
+  nullary = fun _name _output => {
+    name = _name, inputs = [], output = _output,
+  },
+
+  nary = fun _name _inputs _output => {
+    name = _name, inputs = _inputs, output = _output,
+  },
+
+  # ═══════════════════════════════════════════════════════════════════
   # Equation combinators
-  eq = eq,
-  directed_eq = directed_eq,
-  directed_eq_invertible = directed_eq_invertible,
+  # ═══════════════════════════════════════════════════════════════════
 
+  eq = fun _name _lhs _rhs => {
+    name = _name, lhs = _lhs, rhs = _rhs,
+  },
+
+  directed_eq = fun _name _lhs _rhs _impl_expr => {
+    name = _name, lhs = _lhs, rhs = _rhs, impl_expr = _impl_expr,
+  },
+
+  directed_eq_invertible = fun _name _lhs _rhs _impl_expr _inverse => {
+    name = _name, lhs = _lhs, rhs = _rhs,
+    impl_expr = _impl_expr, inverse = _inverse,
+  },
+
+  # ═══════════════════════════════════════════════════════════════════
   # Policy combinators
-  keep_left = keep_left,
-  keep_right = keep_right,
-  fail_on_conflict = fail_on_conflict,
-  custom_policy = custom_policy,
+  # ═══════════════════════════════════════════════════════════════════
 
+  keep_left = fun _name _value_kind => {
+    name = _name, value_kind = _value_kind,
+    strategy = { type = "keep_left" },
+  },
+
+  keep_right = fun _name _value_kind => {
+    name = _name, value_kind = _value_kind,
+    strategy = { type = "keep_right" },
+  },
+
+  fail_on_conflict = fun _name _value_kind => {
+    name = _name, value_kind = _value_kind,
+    strategy = { type = "fail" },
+  },
+
+  custom_policy = fun _name _value_kind _expr => {
+    name = _name, value_kind = _value_kind,
+    strategy = { type = "custom", expr = _expr },
+  },
+
+  # ═══════════════════════════════════════════════════════════════════
   # Composition combinators
-  colimit = colimit,
-  colimit_with_ops = colimit_with_ops,
+  # ═══════════════════════════════════════════════════════════════════
 
+  colimit = fun _left _right _shared_sorts => {
+    left = _left, right = _right,
+    shared_sorts = _shared_sorts, shared_ops = [],
+  },
+
+  colimit_with_ops = fun _left _right _shared_sorts _shared_ops => {
+    left = _left, right = _right,
+    shared_sorts = _shared_sorts, shared_ops = _shared_ops,
+  },
+
+  # ═══════════════════════════════════════════════════════════════════
   # Edge rule combinators
-  edge_rule = edge_rule,
+  # ═══════════════════════════════════════════════════════════════════
+
+  edge_rule = fun _edge_kind _src_kind _tgt_kind => {
+    edge_kind = _edge_kind, src_kind = _src_kind, tgt_kind = _tgt_kind,
+  },
 }


### PR DESCRIPTION
## Summary

- **#154**: Restructure `lens.ncl` and `theory.ncl` as flat records with inline definitions. Prefix combinator parameters with `_` to avoid Nickel record-scope shadowing (`fun _old _new => { old = _old, new = _new }`)
- **#153**: Emit unconsumed structural children after grammar-rule walk, fixing Julia `@trace(args)` short-form macrocall argument dropping
- **#155**: Emit `;` for external hidden rules containing "semicolon" (`_automatic_semicolon`), fixing JavaScript ASI. Add `@` and `#` to prefix-sigil punctuation (no spurious space)

## Test plan

- [x] 6 new Nickel contract regression tests (rename, add, remove, rules, multiple combinators, exhaustive export access)
- [x] 3 new Julia macrocall emit_pretty tests (long-form body, short-form args, no space after @)
- [x] 2 new JavaScript semicolon tests (semicolon presence, error-free re-parse round-trip)
- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS="-D warnings" cargo clippy` on changed crates
- [ ] Full CI

Closes #153, closes #154, closes #155