### PR TITLE
fix(parse): integrate node-types.json into emit_pretty Grammar (0.50.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.50.5] - 2026-05-26
+
+### Fixed
+
+- **`emit_pretty` integrates node-types.json to close grammar/parser divergence** (`panproto-parse`): the Grammar struct now accepts node-types.json alongside grammar.json. A new `build_node_type_children` function parses the authoritative child-kind data, and `augment_subtypes_from_node_types` adds parser-produced child kinds to the subtype closure. This fixes Julia macrocall short-form `@trace(args)` (#153), Julia multi-arg macrocall `@info "msg" foo bar` (#167), and Julia function body re-emit corruption (#164).
+- **`emit_pretty` reverts unconsumed-children fallback** (`panproto-parse`): the v0.50.3 fallback that emitted remaining children after the grammar rule walk caused JavaScript object literal contents to appear outside braces (#159), Stan array sizes to split to the next line (#165), and Stan function parameters to migrate outside parentheses (#166). Removed; the CHOICE fallback now correctly selects non-BLANK when structural children remain.
+- **`emit_pretty` resolves external scanner tokens via precomputed alias map** (`panproto-parse`): `build_external_alias_map` walks all grammar rule bodies at construction time, collecting anonymous ALIAS values for external tokens. The SYMBOL handler checks this map before falling through to name-matching heuristics, fixing JavaScript ternary `?` (#162) and generalizing to all external-token ALIASes.
+- **`emit_pretty` prefers indented CHOICE alternative for by-construction schemas** (`panproto-parse`): when no dispatch tier uniquely identifies a CHOICE alternative and the alternatives include an indented form (containing `_indent` SYMBOL), prefer it over the inline form. The indented form always produces valid output; the inline form (Python `;`-separated statements) is a source-level abbreviation requiring parse-time context. Fixes Julia function body block structure (#164).
+- **`emit_pretty` suppresses brace indentation in interpolation rules** (`panproto-parse`): `identify_inline_brace_rules` structurally identifies rules whose `{`/`}` tokens are inline delimiters (no REPEAT between them) rather than block scopes. The Output struct carries a `suppress_brace_indent` flag threaded through `emit_vertex`.
+
+### Added
+
+- **`Grammar.node_type_children`** (`panproto-parse`): maps parent kind to the set of all named child kinds from node-types.json.
+- **`Grammar.external_alias_map`** (`panproto-parse`): maps external scanner symbol names to their anonymous ALIAS value strings.
+- **`Grammar.inline_brace_rules`** (`panproto-parse`): set of rule names whose `{`/`}` tokens should not trigger block indentation.
+- **`Grammar::from_bytes_with_node_types`** (`panproto-parse`): constructor accepting both grammar.json and node-types.json bytes.
+- **9 regression tests** (`panproto-parse`): one per issue #159-#167, covering JS objects, Python function bodies, f-strings, JS ternaries, template literals, Julia functions/macrocalls, and Stan declarations.
+
 ## [0.50.4] - 2026-05-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "anyhow",
  "miette",
@@ -1994,7 +1994,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "ciborium",
  "panproto-core",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "divan",
  "insta",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "divan",
  "proptest",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "chumsky",
  "divan",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "divan",
  "miette",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "divan",
  "git2",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "git2",
  "miette",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "cc",
  "divan",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-jit"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "divan",
  "inkwell",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "divan",
  "insta",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "divan",
  "miette",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-llvm"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "divan",
  "inkwell",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "divan",
  "memchr",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "blake3",
  "divan",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "blake3",
  "divan",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-repl"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "miette",
  "panproto-gat",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "divan",
  "miette",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "blake3",
  "divan",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.50.4"
+version = "0.50.5"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.50.4"
+version = "0.50.5"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.50.4", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.50.4", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.50.4", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.50.4", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.50.4", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.50.4", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.50.4", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.50.4", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.50.4", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.50.4", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.50.4", path = "crates/panproto-core" }
-panproto-io = { version = "0.50.4", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.50.4", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.50.4", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.50.4", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.50.4", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.50.4", path = "crates/panproto-parse" }
-panproto-project = { version = "0.50.4", path = "crates/panproto-project" }
-panproto-git = { version = "0.50.4", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.50.4", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.50.4", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.50.4", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.50.4", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.50.5", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.50.5", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.50.5", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.50.5", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.50.5", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.50.5", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.50.5", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.50.5", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.50.5", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.50.5", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.50.5", path = "crates/panproto-core" }
+panproto-io = { version = "0.50.5", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.50.5", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.50.5", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.50.5", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.50.5", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.50.5", path = "crates/panproto-parse" }
+panproto-project = { version = "0.50.5", path = "crates/panproto-project" }
+panproto-git = { version = "0.50.5", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.50.5", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.50.5", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.50.5", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.50.5", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.50.4
+version:            0.50.5
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.50.4",
+  "version": "0.50.5",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.4", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.4", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.4", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.50.4", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.4", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.4", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.4", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.4", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.4", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.4", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/src/emit_pretty.rs
+++ b/crates/panproto-parse/src/emit_pretty.rs
@@ -320,6 +320,26 @@ pub struct Grammar {
     /// Epsilon is represented as the empty string `""`.
     #[serde(skip)]
     pub yield_sets: std::collections::HashMap<String, std::collections::HashSet<String>>,
+    /// Child kinds allowed per parent kind, derived from node-types.json.
+    /// Maps parent kind to the set of ALL named child kinds that tree-sitter's
+    /// parser can produce for that parent (from both `children.types` and
+    /// `fields.*.types`). Used by `augment_subtypes_from_node_types` to
+    /// close the grammar/parser divergence gap.
+    #[serde(skip)]
+    pub node_type_children: std::collections::HashMap<String, std::collections::HashSet<String>>,
+    /// Anonymous ALIAS values for external scanner tokens. Maps external
+    /// symbol name (e.g. `_ternary_qmark`) to the ALIAS value string
+    /// (e.g. `"?"`). Built by scanning grammar.json rule bodies for
+    /// `ALIAS { content: SYMBOL S, named: false, value: V }` where S
+    /// has no grammar rule.
+    #[serde(skip)]
+    pub external_alias_map: std::collections::HashMap<String, String>,
+    /// Rules whose `{`/`}` STRING tokens are inline delimiters (e.g.
+    /// string interpolation) rather than block scopes. Identified
+    /// structurally: a rule whose SEQ contains `{` and `}` but no
+    /// REPEAT/REPEAT1 between them.
+    #[serde(skip)]
+    pub inline_brace_rules: std::collections::HashSet<String>,
 }
 
 fn deserialize_supertypes<'de, D>(
@@ -409,12 +429,33 @@ impl Grammar {
     /// Returns [`ParseError::EmitFailed`] when the bytes are not a
     /// valid `grammar.json` document.
     pub fn from_bytes(protocol: &str, bytes: &[u8]) -> Result<Self, ParseError> {
+        Self::from_bytes_with_node_types(protocol, bytes, None)
+    }
+
+    /// Parse a grammar from both `grammar.json` and optionally
+    /// `node-types.json` bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError::EmitFailed`] when `grammar_bytes` is
+    /// not a valid `grammar.json` document.
+    pub fn from_bytes_with_node_types(
+        protocol: &str,
+        grammar_bytes: &[u8],
+        node_types_bytes: Option<&[u8]>,
+    ) -> Result<Self, ParseError> {
         let mut grammar: Self =
-            serde_json::from_slice(bytes).map_err(|e| ParseError::EmitFailed {
+            serde_json::from_slice(grammar_bytes).map_err(|e| ParseError::EmitFailed {
                 protocol: protocol.to_owned(),
                 reason: format!("grammar.json deserialization failed: {e}"),
             })?;
         grammar.subtypes = compute_subtype_closure(&grammar);
+        if let Some(nt_bytes) = node_types_bytes {
+            grammar.node_type_children = build_node_type_children(nt_bytes);
+            augment_subtypes_from_node_types(&mut grammar);
+        }
+        grammar.external_alias_map = build_external_alias_map(&grammar);
+        grammar.inline_brace_rules = identify_inline_brace_rules(&grammar);
         grammar.yield_sets = compute_yield_sets(&grammar);
         Ok(grammar)
     }
@@ -722,6 +763,197 @@ fn yield_of_production(
 }
 
 // ═══════════════════════════════════════════════════════════════════
+// node-types.json integration
+// ═══════════════════════════════════════════════════════════════════
+
+/// Parse node-types.json and build a map from parent kind to the set
+/// of all named child kinds the parser can produce for that parent.
+fn build_node_type_children(
+    nt_bytes: &[u8],
+) -> std::collections::HashMap<String, std::collections::HashSet<String>> {
+    let node_types: Vec<crate::theory_extract::NodeType> = match serde_json::from_slice(nt_bytes) {
+        Ok(v) => v,
+        Err(_) => return std::collections::HashMap::new(),
+    };
+    let mut map: std::collections::HashMap<String, std::collections::HashSet<String>> =
+        std::collections::HashMap::new();
+    for entry in &node_types {
+        if !entry.named {
+            continue;
+        }
+        let mut child_kinds = std::collections::HashSet::new();
+        for field_value in entry.fields.values() {
+            if let Some(types) = field_value.get("types").and_then(|t| t.as_array()) {
+                for t in types {
+                    if let (Some(name), Some(true)) = (
+                        t.get("type").and_then(|n| n.as_str()),
+                        t.get("named").and_then(serde_json::Value::as_bool),
+                    ) {
+                        child_kinds.insert(name.to_owned());
+                    }
+                }
+            }
+        }
+        if let Some(ref children) = entry.children {
+            for t in &children.types {
+                if t.named {
+                    child_kinds.insert(t.node_type.clone());
+                }
+            }
+        }
+        if !child_kinds.is_empty() {
+            map.insert(entry.node_type.clone(), child_kinds);
+        }
+    }
+    map
+}
+
+/// Augment `grammar.subtypes` with child-kind data from node-types.json.
+///
+/// For each parent kind P with node-type children, for each SYMBOL S
+/// referenced in P's grammar rule, for each child kind C in
+/// `node_type_children[P]`: if C does not already satisfy S, record
+/// C satisfies S. This closes the grammar/parser divergence where
+/// tree-sitter's parser produces child kinds not reachable from
+/// grammar.json's production rules.
+fn augment_subtypes_from_node_types(grammar: &mut Grammar) {
+    let pairs: Vec<(String, String)> = grammar
+        .node_type_children
+        .iter()
+        .flat_map(|(parent_kind, allowed_children)| {
+            let symbols: Vec<&str> = grammar
+                .rules
+                .get(parent_kind)
+                .map(|rule| referenced_symbols(rule))
+                .unwrap_or_default();
+            let mut out = Vec::new();
+            for sym_name in &symbols {
+                for child_kind in allowed_children {
+                    if !kind_satisfies_symbol(grammar, Some(child_kind), sym_name) {
+                        out.push((child_kind.clone(), (*sym_name).to_owned()));
+                    }
+                }
+            }
+            out
+        })
+        .collect();
+    for (child_kind, sym_name) in pairs {
+        grammar
+            .subtypes
+            .entry(child_kind)
+            .or_default()
+            .insert(sym_name);
+    }
+}
+
+/// Build a map from external scanner symbol names to their anonymous
+/// ALIAS values by walking every rule body in the grammar.
+fn build_external_alias_map(grammar: &Grammar) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+    fn walk(
+        grammar: &Grammar,
+        prod: &Production,
+        map: &mut std::collections::HashMap<String, String>,
+    ) {
+        match prod {
+            Production::Alias {
+                content,
+                named,
+                value,
+            } => {
+                if !*named && !value.is_empty() {
+                    if let Production::Symbol { name } = content.as_ref() {
+                        if name.starts_with('_') && !grammar.rules.contains_key(name) {
+                            map.entry(name.clone()).or_insert_with(|| value.clone());
+                        }
+                    }
+                }
+                walk(grammar, content, map);
+            }
+            Production::Choice { members } | Production::Seq { members } => {
+                for m in members {
+                    walk(grammar, m, map);
+                }
+            }
+            Production::Repeat { content }
+            | Production::Repeat1 { content }
+            | Production::Optional { content }
+            | Production::Field { content, .. }
+            | Production::Token { content }
+            | Production::ImmediateToken { content }
+            | Production::Prec { content, .. }
+            | Production::PrecLeft { content, .. }
+            | Production::PrecRight { content, .. }
+            | Production::PrecDynamic { content, .. }
+            | Production::Reserved { content, .. } => walk(grammar, content, map),
+            _ => {}
+        }
+    }
+    for rule in grammar.rules.values() {
+        walk(grammar, rule, &mut map);
+    }
+    map
+}
+
+/// Identify rules whose `{`/`}` tokens are inline delimiters (e.g.
+/// interpolation) rather than block scopes. A rule is inline-brace
+/// iff its production SEQ contains both an opening brace token and
+/// `}`, and the members between them contain no REPEAT/REPEAT1
+/// (which would indicate a statement-list block).
+fn identify_inline_brace_rules(grammar: &Grammar) -> std::collections::HashSet<String> {
+    fn is_inline_brace_body(prod: &Production) -> bool {
+        match prod {
+            Production::Seq { members } => {
+                let open_idx = members.iter().position(|m| match m {
+                    Production::String { value } => value.contains('{'),
+                    _ => false,
+                });
+                let close_idx = members
+                    .iter()
+                    .rposition(|m| matches!(m, Production::String { value } if value == "}"));
+                if let (Some(open), Some(close)) = (open_idx, close_idx) {
+                    if open < close {
+                        let between = &members[open + 1..close];
+                        return !has_repeat(between);
+                    }
+                }
+                false
+            }
+            Production::Prec { content, .. }
+            | Production::PrecLeft { content, .. }
+            | Production::PrecRight { content, .. }
+            | Production::PrecDynamic { content, .. }
+            | Production::Token { content }
+            | Production::ImmediateToken { content }
+            | Production::Reserved { content, .. } => is_inline_brace_body(content),
+            _ => false,
+        }
+    }
+    fn has_repeat(members: &[Production]) -> bool {
+        members.iter().any(|m| match m {
+            Production::Repeat { .. } | Production::Repeat1 { .. } => true,
+            Production::Prec { content, .. }
+            | Production::PrecLeft { content, .. }
+            | Production::PrecRight { content, .. }
+            | Production::PrecDynamic { content, .. } => {
+                matches!(
+                    content.as_ref(),
+                    Production::Repeat { .. } | Production::Repeat1 { .. }
+                )
+            }
+            _ => false,
+        })
+    }
+    let mut result = std::collections::HashSet::new();
+    for (name, rule) in &grammar.rules {
+        if is_inline_brace_body(rule) {
+            result.insert(name.clone());
+        }
+    }
+    result
+}
+
+// ═══════════════════════════════════════════════════════════════════
 // Format policy
 // ═══════════════════════════════════════════════════════════════════
 
@@ -867,26 +1099,17 @@ fn emit_vertex(
     let kind = vertex.kind.as_ref();
     let edges = children_for(schema, vertex_id);
     if let Some(rule) = grammar.rules.get(kind) {
+        let old_suppress = out.suppress_brace_indent;
+        if grammar.inline_brace_rules.contains(kind) {
+            out.suppress_brace_indent = true;
+        }
         let mut cursor = ChildCursor::new(&edges);
         emit_production(protocol, schema, grammar, vertex_id, rule, &mut cursor, out)?;
         // Drain any extras left after the rule walk completed; tree-sitter
         // may record trailing comments as children of the surrounding
         // vertex (i.e. after the last structural child the rule matched).
         drain_extras(protocol, schema, grammar, &mut cursor, out)?;
-        // Emit remaining unconsumed structural children that the grammar
-        // rule did not match. This covers cases where tree-sitter's parser
-        // produces child kinds not reachable from grammar.json's production
-        // rules (e.g. Julia's macrocall_expression can have an
-        // `argument_list` child even though the grammar only references
-        // `macro_argument_list`).
-        for (i, edge) in cursor.edges.iter().enumerate() {
-            if !cursor.consumed[i] {
-                let child_kind = schema.vertices.get(&edge.tgt).map(|v| v.kind.as_ref());
-                if child_kind.is_some_and(|k| !grammar.extras.contains(k)) {
-                    emit_vertex(protocol, schema, grammar, &edge.tgt, out)?;
-                }
-            }
-        }
+        out.suppress_brace_indent = old_suppress;
         return Ok(());
     }
 
@@ -1209,9 +1432,14 @@ fn emit_production_inner(
                     //   grammars like TOML whose `pair` SEQ trails
                     //   into `_line_ending_or_eof`.
                     //
-                    // Anything else falls through silently — better
-                    // to drop an unknown external token than to
-                    // invent one that confuses re-parsing.
+                    // Check the precomputed alias map first: if this
+                    // external token appears as the content of an
+                    // anonymous ALIAS elsewhere in the grammar, emit
+                    // the alias value as the token text.
+                    if let Some(alias_value) = grammar.external_alias_map.get(name) {
+                        out.token(alias_value);
+                        return Ok(());
+                    }
                     if name == "_indent" || name.ends_with("_indent") {
                         out.indent_open();
                     } else if name == "_dedent" || name.ends_with("_dedent") {
@@ -1438,6 +1666,20 @@ fn emit_production_inner(
                         .unwrap_or(false)
                 }) {
                     return emit_aliased_child(protocol, schema, grammar, &edge.tgt, content, out);
+                }
+            }
+            // For anonymous aliases (named: false) whose content is an
+            // external scanner token with no grammar rule (e.g.
+            // JavaScript's `_ternary_qmark` aliased to `"?"`), emit the
+            // alias value directly. The content's SYMBOL handler would
+            // fall through the external-token heuristic and produce
+            // nothing; the alias value IS the token text.
+            if !*named && !value.is_empty() {
+                if let Production::Symbol { name: sym } = content.as_ref() {
+                    if sym.starts_with('_') && !grammar.rules.contains_key(sym) {
+                        out.token(value);
+                        return Ok(());
+                    }
                 }
             }
             emit_production(protocol, schema, grammar, vertex_id, content, cursor, out)
@@ -1900,19 +2142,51 @@ fn pick_choice_with_cursor<'a>(
         }
     }
 
-    // No cursor-driven match. Fall back to:
+    // Indented-form preference: when no dispatch tier uniquely
+    // identified an alternative and the cursor has children, prefer
+    // the alternative whose production body contains an `_indent`
+    // SYMBOL. The indented form is always valid for by-construction
+    // schemas and round-trips cleanly; the inline form (e.g. Python's
+    // `;`-separated `_simple_statements`) is a source-level
+    // abbreviation that requires parse-time context to select correctly.
+    if first_unconsumed_kind.is_some() {
+        let indent_alt = alternatives.iter().find(|alt| {
+            referenced_symbols(alt)
+                .iter()
+                .any(|s| *s == "_indent" || s.ends_with("_indent"))
+        });
+        if let Some(alt) = indent_alt {
+            return Some(alt);
+        }
+    }
+
+    // No dispatch tier matched. The final selection follows the
+    // categorical semantics of CHOICE-with-BLANK: BLANK represents ε
+    // (produce nothing at this position). It is correct if and only
+    // if no child remains to consume at this cursor position.
     //
-    // - BLANK (the explicit empty alternative) when present, so an
-    //   OPTIONAL-shaped CHOICE compiles to nothing.
-    // - The first non-`BLANK` alternative as a last resort, used by
-    //   STRING-only alternatives (keyword tokens) and other choices
-    //   that don't reach the cursor.
-    //
-    // The previous "match own_kind" branch is intentionally absent:
-    // when an alt's first SYMBOL equals the current vertex's kind, the
-    // caller is already emitting that vertex's own rule. Recursing
-    // into the alt would cause a self-loop in the rule walk.
+    // When unconsumed non-extra children remain, selecting BLANK
+    // would silently drop them. Select the first non-BLANK
+    // alternative instead so the production walk can attempt to
+    // consume them (the grammar rule may reference a symbol name
+    // that doesn't exactly match the parse output's child kind,
+    // e.g. Julia's macrocall_expression receives `argument_list`
+    // children when grammar.json only references
+    // `macro_argument_list`).
     let _ = (schema, vertex_id);
+    let has_unconsumed_structural = cursor.edges.iter().enumerate().any(|(i, edge)| {
+        !cursor.consumed[i]
+            && schema
+                .vertices
+                .get(&edge.tgt)
+                .map(|v| !grammar.extras.contains(v.kind.as_ref()))
+                .unwrap_or(false)
+    });
+    if has_unconsumed_structural {
+        return alternatives
+            .iter()
+            .find(|alt| !matches!(alt, Production::Blank));
+    }
     if alternatives.iter().any(|a| matches!(a, Production::Blank)) {
         return alternatives.iter().find(|a| matches!(a, Production::Blank));
     }
@@ -2288,6 +2562,7 @@ enum Token {
 struct Output<'a> {
     tokens: Vec<Token>,
     policy: &'a FormatPolicy,
+    suppress_brace_indent: bool,
 }
 
 #[derive(Clone)]
@@ -2300,6 +2575,7 @@ impl<'a> Output<'a> {
         Self {
             tokens: Vec::new(),
             policy,
+            suppress_brace_indent: false,
         }
     }
 
@@ -2331,11 +2607,12 @@ impl<'a> Output<'a> {
         let trimmed = value.trim_end_matches(['\n', '\r']);
         let trailing_newlines = value.len() - trimmed.len();
         if trailing_newlines > 0 && !trimmed.is_empty() {
-            if self.policy.indent_close.iter().any(|t| t == trimmed) {
+            if !self.suppress_brace_indent && self.policy.indent_close.iter().any(|t| t == trimmed)
+            {
                 self.tokens.push(Token::IndentClose);
             }
             self.tokens.push(Token::Lit(trimmed.to_owned()));
-            if self.policy.indent_open.iter().any(|t| t == trimmed) {
+            if !self.suppress_brace_indent && self.policy.indent_open.iter().any(|t| t == trimmed) {
                 self.tokens.push(Token::IndentOpen);
             } else if self.policy.line_break_after.iter().any(|t| t == trimmed) {
                 // already emitting a LineBreak below for the trailing \n
@@ -2344,13 +2621,13 @@ impl<'a> Output<'a> {
             return;
         }
 
-        if self.policy.indent_close.iter().any(|t| t == value) {
+        if !self.suppress_brace_indent && self.policy.indent_close.iter().any(|t| t == value) {
             self.tokens.push(Token::IndentClose);
         }
 
         self.tokens.push(Token::Lit(value.to_owned()));
 
-        if self.policy.indent_open.iter().any(|t| t == value) {
+        if !self.suppress_brace_indent && self.policy.indent_open.iter().any(|t| t == value) {
             self.tokens.push(Token::IndentOpen);
             self.tokens.push(Token::LineBreak);
         } else if self.policy.line_break_after.iter().any(|t| t == value) {

--- a/crates/panproto-parse/src/languages/common.rs
+++ b/crates/panproto-parse/src/languages/common.rs
@@ -54,6 +54,9 @@ pub struct LanguageParser {
     /// when the upstream grammar does not ship `grammar.json` and
     /// `tools/fetch-grammar-json.py` could not regenerate one.
     grammar_json: Option<&'static [u8]>,
+    /// Raw `node-types.json` bytes for augmenting the Grammar's subtype
+    /// closure with parser-produced child kinds not in grammar.json.
+    node_types_json_for_emit: Option<Vec<u8>>,
     /// Lazily-parsed grammar. Populated on first call to `emit_pretty`.
     grammar_cache: OnceLock<Result<EmitGrammar, ParseError>>,
 }
@@ -126,6 +129,7 @@ impl LanguageParser {
             walker_config,
             scope_detector: Mutex::new(scope_detector),
             grammar_json,
+            node_types_json_for_emit: Some(node_types_json.to_vec()),
             grammar_cache: OnceLock::new(),
         })
     }
@@ -228,9 +232,10 @@ impl AstParser for LanguageParser {
                      run tools/fetch-grammar-json.py to populate it"
                 .to_owned(),
         })?;
-        let cached = self
-            .grammar_cache
-            .get_or_init(|| EmitGrammar::from_bytes(&self.protocol_name, bytes));
+        let nt = self.node_types_json_for_emit.as_deref();
+        let cached = self.grammar_cache.get_or_init(|| {
+            EmitGrammar::from_bytes_with_node_types(&self.protocol_name, bytes, nt)
+        });
         let grammar = match cached {
             Ok(g) => g,
             Err(e) => {

--- a/crates/panproto-parse/tests/emit_pretty_regressions.rs
+++ b/crates/panproto-parse/tests/emit_pretty_regressions.rs
@@ -1,0 +1,216 @@
+//! Regression tests for `emit_pretty` issues #159-#167.
+//!
+//! Tests marked `#[ignore]` document pre-existing limitations that
+//! require deeper fixes (node-types.json augmentation, layout policy
+//! enhancements). They serve as executable documentation and will be
+//! un-ignored as fixes land.
+
+#![cfg(feature = "grammars")]
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use panproto_parse::ParserRegistry;
+use panproto_schema::Schema;
+
+fn registry() -> ParserRegistry {
+    ParserRegistry::new()
+}
+
+fn strip_byte_fragments(schema: &mut Schema) {
+    for constraints in schema.constraints.values_mut() {
+        constraints.retain(|c| {
+            let s = c.sort.as_ref();
+            !(s == "start-byte" || s == "end-byte" || s.starts_with("interstitial-"))
+        });
+    }
+}
+
+fn with_big_stack<F: FnOnce() + Send + 'static>(inner: F) {
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(inner)
+        .expect("spawn")
+        .join()
+        .expect("worker panicked");
+}
+
+fn emit_stripped(reg: &ParserRegistry, protocol: &str, src: &[u8]) -> String {
+    let mut schema = reg
+        .parse_with_protocol(protocol, src, &format!("test.{protocol}"))
+        .unwrap_or_else(|e| panic!("parse failed: {e}"));
+    strip_byte_fragments(&mut schema);
+    let emitted = reg
+        .emit_pretty_with_protocol(protocol, &schema)
+        .unwrap_or_else(|e| panic!("emit_pretty failed: {e}"));
+    String::from_utf8(emitted).expect("non-utf8 emit")
+}
+
+// ---------------------------------------------------------------
+// #159: JavaScript object literal contents outside braces
+// ---------------------------------------------------------------
+
+#[test]
+fn js_object_literal_contents_inside_braces() {
+    with_big_stack(|| {
+        let reg = registry();
+        let text = emit_stripped(&reg, "javascript", b"var x = {a: 1, b: 2};\n");
+        assert!(
+            !text.contains("}\na") && !text.contains("}\n  a"),
+            "#159: object pair children must be inside braces, got: {text}"
+        );
+    });
+}
+
+// ---------------------------------------------------------------
+// #160: Python function body `;` vs `\n` fixed-point regression
+// ---------------------------------------------------------------
+
+#[test]
+#[ignore = "pre-existing: Python _simple_statements grammar uses ';' as REPEAT separator (#160)"]
+fn python_function_body_no_semicolons() {
+    with_big_stack(|| {
+        let reg = registry();
+        let text = emit_stripped(&reg, "python", b"def f():\n    x = 1\n    return x\n");
+        assert!(
+            !text.contains(';'),
+            "#160: Python function body should not use ';', got: {text}"
+        );
+    });
+}
+
+// ---------------------------------------------------------------
+// #161: Python f-string interpolation mangled
+// ---------------------------------------------------------------
+
+#[test]
+#[ignore = "pre-existing: interpolation expressions formatted as blocks (#161)"]
+fn python_fstring_interpolation_inline() {
+    with_big_stack(|| {
+        let reg = registry();
+        let text = emit_stripped(&reg, "python", b"s = f\"x={x}\"\n");
+        assert!(
+            !text.contains("{\n"),
+            "#161: f-string interpolation must be inline, got: {text}"
+        );
+    });
+}
+
+// ---------------------------------------------------------------
+// #162: JavaScript ternary '?' dropped
+// ---------------------------------------------------------------
+
+#[test]
+fn js_ternary_preserves_question_mark() {
+    with_big_stack(|| {
+        let reg = registry();
+        let text = emit_stripped(&reg, "javascript", b"var x = a ? b : c;\n");
+        assert!(
+            text.contains('?'),
+            "#162: ternary must preserve '?', got: {text}"
+        );
+    });
+}
+
+// ---------------------------------------------------------------
+// #163: JavaScript template literal mangled
+// ---------------------------------------------------------------
+
+#[test]
+#[ignore = "pre-existing: template literal interpolation formatted as blocks (#163)"]
+fn js_template_literal_interpolation_inline() {
+    with_big_stack(|| {
+        let reg = registry();
+        let text = emit_stripped(&reg, "javascript", b"var s = `hello ${name}`;\n");
+        assert!(
+            !text.contains("${\n") && !text.contains("${ "),
+            "#163: template interpolation must be inline, got: {text}"
+        );
+    });
+}
+
+// ---------------------------------------------------------------
+// #164: Julia function body emitted inline
+// ---------------------------------------------------------------
+
+#[test]
+#[cfg(feature = "lang-julia")]
+fn julia_function_body_not_inline() {
+    with_big_stack(|| {
+        let reg = registry();
+        let text = emit_stripped(
+            &reg,
+            "julia",
+            b"function f()\n    x = 1\n    y = 2\n    x + y\nend\n",
+        );
+        let reparsed = reg
+            .parse_with_protocol("julia", text.as_bytes(), "rt.jl")
+            .expect("reparse");
+        let errors = reparsed
+            .vertices
+            .values()
+            .filter(|v| v.kind.as_ref() == "ERROR")
+            .count();
+        assert_eq!(
+            errors, 0,
+            "#164: re-parsed Julia should have 0 ERROR nodes, got {errors}\nemitted:\n{text}"
+        );
+    });
+}
+
+// ---------------------------------------------------------------
+// #165: Stan array declaration size split
+// ---------------------------------------------------------------
+
+#[test]
+#[cfg(feature = "lang-stan")]
+fn stan_array_size_inside_declaration() {
+    with_big_stack(|| {
+        let reg = registry();
+        let text = emit_stripped(&reg, "stan", b"data { real x[10]; }\n");
+        let bracket_pos = text.find('[');
+        let semi_pos = text.find(';');
+        if let (Some(bp), Some(sp)) = (bracket_pos, semi_pos) {
+            assert!(
+                bp < sp,
+                "#165: array size '[10]' must be before ';', got: {text}"
+            );
+        }
+    });
+}
+
+// ---------------------------------------------------------------
+// #166: Stan function declaration parameter list
+// ---------------------------------------------------------------
+
+#[test]
+#[cfg(feature = "lang-stan")]
+fn stan_function_params_inside_parens() {
+    with_big_stack(|| {
+        let reg = registry();
+        let text = emit_stripped(
+            &reg,
+            "stan",
+            b"functions { real sq(real x) { return x * x; } } model {}\n",
+        );
+        assert!(
+            !text.contains("sq() real x"),
+            "#166: function params must be inside parens, got: {text}"
+        );
+    });
+}
+
+// ---------------------------------------------------------------
+// #167: Julia multi-argument macrocall
+// ---------------------------------------------------------------
+
+#[test]
+#[cfg(feature = "lang-julia")]
+fn julia_macrocall_multi_arg_preserves_all() {
+    with_big_stack(|| {
+        let reg = registry();
+        let text = emit_stripped(&reg, "julia", b"@info \"msg\" foo bar\n");
+        assert!(
+            text.contains("foo") && text.contains("bar"),
+            "#167: multi-arg macrocall must preserve all args, got: {text}"
+        );
+    });
+}


### PR DESCRIPTION
## Summary

Integrates tree-sitter's node-types.json into the emit_pretty Grammar struct, closing the grammar/parser divergence that caused children to be unrecognized and dropped across JavaScript, Python, Julia, and Stan grammars.

**Fixes**: #153, #159, #162, #164, #165, #166, #167
**Documents** (with `#[ignore]` regression tests): #160, #161, #163

### Changes

1. **node-types.json integration**: `Grammar::from_bytes_with_node_types` constructor. `build_node_type_children` + `augment_subtypes_from_node_types` augment the subtype closure with parser-produced child kinds.
2. **External token resolution**: `build_external_alias_map` precomputes anonymous ALIAS values. SYMBOL handler checks map before name heuristics.
3. **Inline brace detection**: `identify_inline_brace_rules` structurally identifies interpolation-like rules. `Output.suppress_brace_indent` flag threaded through `emit_vertex`.
4. **CHOICE disambiguation**: Prefer indented alternative (contains `_indent`) for by-construction schemas. BLANK only when no structural children remain.
5. **Revert unconsumed-children fallback** from v0.50.3.

## Test plan

- [x] 62 base tests + 9 regression tests pass (3 `#[ignore]`)
- [x] Julia macrocall (long-form, short-form, multi-arg, no-space-after-@): 3 pass
- [x] Python with-as: 2 pass
- [x] Julia function body, JS object, JS ternary, Stan array/function: all pass
- [x] `cargo fmt`, `cargo clippy -D warnings`
- [ ] Full CI