### PR TITLE
fix(parse): inline-brace suppression, indented-form preference, phantom token fix (0.50.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.50.6] - 2026-05-26
+
+### Fixed
+
+- **`emit_pretty` CHOICE dispatch no longer emits phantom tokens** (`panproto-parse`): the BLANK-over-non-BLANK fallback (introduced in v0.50.5) incorrectly selected non-BLANK alternatives for CHOICE positions whose children belonged to later SEQ members, inserting phantom tokens like `async` and `->` in Python function definitions. Removed the fallback: BLANK is now always selected when no dispatch tier matches, which is categorically correct (children that don't match this CHOICE position belong to a later SEQ member). The node-types.json augmentation from v0.50.5 handles the Julia macrocall case that originally motivated the fallback.
+- **`emit_pretty` inline-brace suppression now covers `line_break_after`** (`panproto-parse`): `{` and `}` tokens inside inline-brace rules (interpolation, template substitution) no longer trigger `LineBreak` from the `line_break_after` policy vector. Previously, even with `suppress_brace_indent` active, the `line_break_after` check still fired as a fallback. Fixes Python f-string interpolation (#161) and JavaScript template literal interpolation (#163).
+- **`is_punct_open` recognizes compound opening tokens** (`panproto-parse`): tokens ending with `{`, `(`, or `[` (e.g. `${`, `#{`) are now treated as opening punctuation, suppressing the inter-token space. Fixes `${ name}` → `${name}` in JS template literals.
+- **`emit_pretty` indented-form CHOICE preference fires before standard dispatch** (`panproto-parse`): when multiple CHOICE alternatives yield the same child kind (e.g. Python `_suite` where all three alternatives produce `block`), the alternative containing `_indent` is selected before the standard direct-match pass that would pick the first grammar-order match. Selects the indented block form for Python function bodies instead of the inline `;`-separated form.
+
 ## [0.50.5] - 2026-05-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "anyhow",
  "miette",
@@ -1994,7 +1994,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "ciborium",
  "panproto-core",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "divan",
  "insta",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "divan",
  "proptest",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "chumsky",
  "divan",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "divan",
  "miette",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "divan",
  "git2",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "git2",
  "miette",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "cc",
  "divan",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-jit"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "divan",
  "inkwell",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "divan",
  "insta",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "divan",
  "miette",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-llvm"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "divan",
  "inkwell",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "divan",
  "memchr",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "blake3",
  "divan",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "blake3",
  "divan",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-repl"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "miette",
  "panproto-gat",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "divan",
  "miette",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "blake3",
  "divan",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.50.5"
+version = "0.50.6"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.50.5"
+version = "0.50.6"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.50.5", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.50.5", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.50.5", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.50.5", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.50.5", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.50.5", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.50.5", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.50.5", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.50.5", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.50.5", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.50.5", path = "crates/panproto-core" }
-panproto-io = { version = "0.50.5", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.50.5", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.50.5", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.50.5", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.50.5", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.50.5", path = "crates/panproto-parse" }
-panproto-project = { version = "0.50.5", path = "crates/panproto-project" }
-panproto-git = { version = "0.50.5", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.50.5", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.50.5", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.50.5", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.50.5", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.50.6", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.50.6", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.50.6", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.50.6", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.50.6", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.50.6", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.50.6", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.50.6", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.50.6", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.50.6", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.50.6", path = "crates/panproto-core" }
+panproto-io = { version = "0.50.6", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.50.6", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.50.6", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.50.6", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.50.6", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.50.6", path = "crates/panproto-parse" }
+panproto-project = { version = "0.50.6", path = "crates/panproto-project" }
+panproto-git = { version = "0.50.6", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.50.6", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.50.6", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.50.6", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.50.6", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.50.5
+version:            0.50.6
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.50.5",
+  "version": "0.50.6",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.5", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/src/emit_pretty.rs
+++ b/crates/panproto-parse/src/emit_pretty.rs
@@ -2076,6 +2076,37 @@ fn pick_choice_with_cursor<'a>(
         //      for non-SYMBOL alternatives (ALIAS, SEQ, etc.)
         let target_supers = grammar.subtypes.get(target_kind);
 
+        // Indented-form preference: when multiple alternatives match
+        // the target kind (e.g. Python _suite where all three alts
+        // produce `block`), prefer the alternative containing an
+        // `_indent` SYMBOL. Check this BEFORE the standard passes
+        // since they would pick the first match in grammar order.
+        {
+            let mut match_count = 0usize;
+            let mut indent_alt_idx: Option<usize> = None;
+            let mut visited = std::collections::HashSet::new();
+            let mut yield_cache = grammar.yield_sets.clone();
+            for (i, alt) in alternatives.iter().enumerate() {
+                let ys = yield_of_production(grammar, alt, &mut visited, &mut yield_cache);
+                if ys.contains(target_kind) {
+                    match_count += 1;
+                    if indent_alt_idx.is_none()
+                        && referenced_symbols(alt)
+                            .iter()
+                            .any(|s| *s == "_indent" || s.ends_with("_indent"))
+                    {
+                        indent_alt_idx = Some(i);
+                    }
+                }
+                visited.clear();
+            }
+            if match_count > 1 {
+                if let Some(idx) = indent_alt_idx {
+                    return Some(&alternatives[idx]);
+                }
+            }
+        }
+
         // Pass 1: direct name match
         for alt in alternatives {
             if let Production::Symbol { name } = alt {
@@ -2142,24 +2173,6 @@ fn pick_choice_with_cursor<'a>(
         }
     }
 
-    // Indented-form preference: when no dispatch tier uniquely
-    // identified an alternative and the cursor has children, prefer
-    // the alternative whose production body contains an `_indent`
-    // SYMBOL. The indented form is always valid for by-construction
-    // schemas and round-trips cleanly; the inline form (e.g. Python's
-    // `;`-separated `_simple_statements`) is a source-level
-    // abbreviation that requires parse-time context to select correctly.
-    if first_unconsumed_kind.is_some() {
-        let indent_alt = alternatives.iter().find(|alt| {
-            referenced_symbols(alt)
-                .iter()
-                .any(|s| *s == "_indent" || s.ends_with("_indent"))
-        });
-        if let Some(alt) = indent_alt {
-            return Some(alt);
-        }
-    }
-
     // No dispatch tier matched. The final selection follows the
     // categorical semantics of CHOICE-with-BLANK: BLANK represents ε
     // (produce nothing at this position). It is correct if and only
@@ -2174,19 +2187,6 @@ fn pick_choice_with_cursor<'a>(
     // children when grammar.json only references
     // `macro_argument_list`).
     let _ = (schema, vertex_id);
-    let has_unconsumed_structural = cursor.edges.iter().enumerate().any(|(i, edge)| {
-        !cursor.consumed[i]
-            && schema
-                .vertices
-                .get(&edge.tgt)
-                .map(|v| !grammar.extras.contains(v.kind.as_ref()))
-                .unwrap_or(false)
-    });
-    if has_unconsumed_structural {
-        return alternatives
-            .iter()
-            .find(|alt| !matches!(alt, Production::Blank));
-    }
     if alternatives.iter().any(|a| matches!(a, Production::Blank)) {
         return alternatives.iter().find(|a| matches!(a, Production::Blank));
     }
@@ -2630,7 +2630,9 @@ impl<'a> Output<'a> {
         if !self.suppress_brace_indent && self.policy.indent_open.iter().any(|t| t == value) {
             self.tokens.push(Token::IndentOpen);
             self.tokens.push(Token::LineBreak);
-        } else if self.policy.line_break_after.iter().any(|t| t == value) {
+        } else if self.policy.line_break_after.iter().any(|t| t == value)
+            && !(self.suppress_brace_indent && (value == "{" || value == "}"))
+        {
             self.tokens.push(Token::LineBreak);
         }
     }
@@ -2833,6 +2835,9 @@ fn first_is_operand_start(s: &str) -> bool {
 
 fn is_punct_open(s: &str) -> bool {
     matches!(s, "(" | "[" | "{" | "\"" | "'" | "`" | "@" | "#")
+        || s.ends_with('{')
+        || s.ends_with('(')
+        || s.ends_with('[')
 }
 
 fn is_punct_close(s: &str) -> bool {

--- a/crates/panproto-parse/tests/emit_pretty_regressions.rs
+++ b/crates/panproto-parse/tests/emit_pretty_regressions.rs
@@ -65,7 +65,7 @@ fn js_object_literal_contents_inside_braces() {
 // ---------------------------------------------------------------
 
 #[test]
-#[ignore = "pre-existing: Python _simple_statements grammar uses ';' as REPEAT separator (#160)"]
+#[ignore = "Python _simple_statements uses ';' as grammar-valid separator; eliminating requires per-rule format policy (#160)"]
 fn python_function_body_no_semicolons() {
     with_big_stack(|| {
         let reg = registry();
@@ -82,7 +82,6 @@ fn python_function_body_no_semicolons() {
 // ---------------------------------------------------------------
 
 #[test]
-#[ignore = "pre-existing: interpolation expressions formatted as blocks (#161)"]
 fn python_fstring_interpolation_inline() {
     with_big_stack(|| {
         let reg = registry();
@@ -115,7 +114,6 @@ fn js_ternary_preserves_question_mark() {
 // ---------------------------------------------------------------
 
 #[test]
-#[ignore = "pre-existing: template literal interpolation formatted as blocks (#163)"]
 fn js_template_literal_interpolation_inline() {
     with_big_stack(|| {
         let reg = registry();


### PR DESCRIPTION
## Summary

- **#161**: Python f-string interpolation `{x}` no longer mangled to multi-line block form
- **#163**: JS template literal `${name}` no longer mangled with extra spaces/newlines
- Removed BLANK-over-non-BLANK CHOICE fallback that inserted phantom `async`/`->` tokens
- Indented-form CHOICE preference fires before standard dispatch for Python `_suite`

## Test plan

- [x] 64 base + 11 feature-gated tests pass (1 `#[ignore]` for #160)
- [x] `cargo fmt`, `cargo clippy -D warnings`
- [ ] Full CI

Closes #161, closes #163