### PR TITLE
fix(parse): restrict node-types.json subtype augmentation to unmatched children (0.50.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.50.7] - 2026-05-26
+
+### Fixed
+
+- **node-types.json subtype augmentation restricted to unmatched children** (`panproto-parse`): `augment_subtypes_from_node_types` now skips child kinds that already satisfy at least one symbol in the parent's grammar rule. The v0.50.5 augmentation was too aggressive: it added every node-types.json child kind as satisfying every referenced symbol, causing CHOICE dispatch to pick wrong alternatives (Python assignment `x = 1` emitted as `x: = 1` because `integer` was added as satisfying `type` in addition to `_right_hand_side`; Stan `vector[N] y` emitted as `vector N[] y`; Scheme produced empty output).
+- **Removed issue-number references from doc comments and test assertions** (`panproto-parse`, `panproto-lens-dsl`).
+
 ## [0.50.6] - 2026-05-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "anyhow",
  "miette",
@@ -1994,7 +1994,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "ciborium",
  "panproto-core",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "divan",
  "insta",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "divan",
  "proptest",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "chumsky",
  "divan",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "divan",
  "miette",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "divan",
  "git2",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "git2",
  "miette",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "cc",
  "divan",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-jit"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "divan",
  "inkwell",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "divan",
  "insta",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "divan",
  "miette",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-llvm"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "divan",
  "inkwell",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "divan",
  "memchr",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "blake3",
  "divan",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "blake3",
  "divan",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-repl"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "miette",
  "panproto-gat",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "divan",
  "miette",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "blake3",
  "divan",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.50.6"
+version = "0.50.7"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.50.6"
+version = "0.50.7"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.25"
 tree-sitter-tags = "0.25"
 
 # Workspace crates
-panproto-gat = { version = "0.50.6", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.50.6", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.50.6", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.50.6", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.50.6", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.50.6", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.50.6", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.50.6", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.50.6", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.50.6", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.50.6", path = "crates/panproto-core" }
-panproto-io = { version = "0.50.6", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.50.6", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.50.6", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.50.6", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.50.6", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.50.6", path = "crates/panproto-parse" }
-panproto-project = { version = "0.50.6", path = "crates/panproto-project" }
-panproto-git = { version = "0.50.6", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.50.6", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.50.6", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.50.6", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.50.6", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.50.7", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.50.7", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.50.7", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.50.7", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.50.7", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.50.7", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.50.7", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.50.7", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.50.7", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.50.7", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.50.7", path = "crates/panproto-core" }
+panproto-io = { version = "0.50.7", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.50.7", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.50.7", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.50.7", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.50.7", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.50.7", path = "crates/panproto-parse" }
+panproto-project = { version = "0.50.7", path = "crates/panproto-project" }
+panproto-git = { version = "0.50.7", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.50.7", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.50.7", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.50.7", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.50.7", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.50.6
+version:            0.50.7
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.50.6",
+  "version": "0.50.7",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.50.7", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.50.7", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.50.7", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.50.7", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.50.7", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.50.7", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.50.7", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.50.7", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.50.7", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.50.6", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.50.7", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-lens-dsl/tests/nickel_contract.rs
+++ b/crates/panproto-lens-dsl/tests/nickel_contract.rs
@@ -1,8 +1,8 @@
 //! Regression tests for the bundled lens.ncl Nickel contract module.
 //!
 //! These tests exercise the full Nickel evaluation path to catch
-//! reserved-word collisions (#144), missing-definition errors (#151),
-//! and infinite-recursion regressions (#154) before they ship.
+//! reserved-word collisions, missing-definition errors,
+//! and infinite-recursion regressions before they ship.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 

--- a/crates/panproto-parse/src/emit_pretty.rs
+++ b/crates/panproto-parse/src/emit_pretty.rs
@@ -827,11 +827,21 @@ fn augment_subtypes_from_node_types(grammar: &mut Grammar) {
                 .map(|rule| referenced_symbols(rule))
                 .unwrap_or_default();
             let mut out = Vec::new();
-            for sym_name in &symbols {
-                for child_kind in allowed_children {
-                    if !kind_satisfies_symbol(grammar, Some(child_kind), sym_name) {
-                        out.push((child_kind.clone(), (*sym_name).to_owned()));
-                    }
+            for child_kind in allowed_children {
+                // Only augment if this child kind doesn't already
+                // satisfy ANY symbol referenced by this parent's rule.
+                // If it already has a home (e.g. `integer` satisfies
+                // `_right_hand_side`), adding it as satisfying `type`
+                // would cause CHOICE dispatch to pick the wrong
+                // alternative.
+                let already_satisfies_some = symbols
+                    .iter()
+                    .any(|s| kind_satisfies_symbol(grammar, Some(child_kind), s));
+                if already_satisfies_some {
+                    continue;
+                }
+                for sym_name in &symbols {
+                    out.push((child_kind.clone(), (*sym_name).to_owned()));
                 }
             }
             out

--- a/crates/panproto-parse/tests/emit_pretty_js_semicolons.rs
+++ b/crates/panproto-parse/tests/emit_pretty_js_semicolons.rs
@@ -1,4 +1,4 @@
-//! Regression test for JavaScript automatic semicolon insertion (#155).
+//! Regression test for JavaScript automatic semicolon insertion.
 //!
 //! Verifies that `emit_pretty` inserts semicolons between sibling
 //! statements in a `statement_block`, producing output that JavaScript's

--- a/crates/panproto-parse/tests/emit_pretty_julia_macrocall.rs
+++ b/crates/panproto-parse/tests/emit_pretty_julia_macrocall.rs
@@ -1,4 +1,4 @@
-//! Regression tests for Julia macrocall `emit_pretty` (#150, #153).
+//! Regression tests for Julia macrocall `emit_pretty`.
 //!
 //! Verifies that both long-form (`@model function ... end`) and
 //! short-form (`@trace(args)`) macrocall expressions round-trip

--- a/crates/panproto-parse/tests/emit_pretty_python_as_pattern.rs
+++ b/crates/panproto-parse/tests/emit_pretty_python_as_pattern.rs
@@ -1,4 +1,4 @@
-//! Regression test for Python `with X as Y:` `emit_pretty` (#157).
+//! Regression test for Python `with X as Y:` `emit_pretty`.
 //!
 //! Verifies that the `as_pattern_target` identifier survives the
 //! `emit_pretty` round-trip.

--- a/crates/panproto-parse/tests/emit_pretty_regressions.rs
+++ b/crates/panproto-parse/tests/emit_pretty_regressions.rs
@@ -1,9 +1,5 @@
-//! Regression tests for `emit_pretty` issues #159-#167.
-//!
-//! Tests marked `#[ignore]` document pre-existing limitations that
-//! require deeper fixes (node-types.json augmentation, layout policy
-//! enhancements). They serve as executable documentation and will be
-//! un-ignored as fixes land.
+//! Regression tests for `emit_pretty` across JavaScript, Python,
+//! Julia, Stan, and Scheme grammars.
 
 #![cfg(feature = "grammars")]
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
@@ -44,10 +40,6 @@ fn emit_stripped(reg: &ParserRegistry, protocol: &str, src: &[u8]) -> String {
     String::from_utf8(emitted).expect("non-utf8 emit")
 }
 
-// ---------------------------------------------------------------
-// #159: JavaScript object literal contents outside braces
-// ---------------------------------------------------------------
-
 #[test]
 fn js_object_literal_contents_inside_braces() {
     with_big_stack(|| {
@@ -55,31 +47,23 @@ fn js_object_literal_contents_inside_braces() {
         let text = emit_stripped(&reg, "javascript", b"var x = {a: 1, b: 2};\n");
         assert!(
             !text.contains("}\na") && !text.contains("}\n  a"),
-            "#159: object pair children must be inside braces, got: {text}"
+            "object pair children must be inside braces, got: {text}"
         );
     });
 }
 
-// ---------------------------------------------------------------
-// #160: Python function body `;` vs `\n` fixed-point regression
-// ---------------------------------------------------------------
-
 #[test]
-#[ignore = "Python _simple_statements uses ';' as grammar-valid separator; eliminating requires per-rule format policy (#160)"]
+#[ignore = "Python _simple_statements uses ';' as grammar-valid separator; eliminating requires per-rule format policy"]
 fn python_function_body_no_semicolons() {
     with_big_stack(|| {
         let reg = registry();
         let text = emit_stripped(&reg, "python", b"def f():\n    x = 1\n    return x\n");
         assert!(
             !text.contains(';'),
-            "#160: Python function body should not use ';', got: {text}"
+            "Python function body should not use ';', got: {text}"
         );
     });
 }
-
-// ---------------------------------------------------------------
-// #161: Python f-string interpolation mangled
-// ---------------------------------------------------------------
 
 #[test]
 fn python_fstring_interpolation_inline() {
@@ -88,30 +72,19 @@ fn python_fstring_interpolation_inline() {
         let text = emit_stripped(&reg, "python", b"s = f\"x={x}\"\n");
         assert!(
             !text.contains("{\n"),
-            "#161: f-string interpolation must be inline, got: {text}"
+            "f-string interpolation must be inline, got: {text}"
         );
     });
 }
-
-// ---------------------------------------------------------------
-// #162: JavaScript ternary '?' dropped
-// ---------------------------------------------------------------
 
 #[test]
 fn js_ternary_preserves_question_mark() {
     with_big_stack(|| {
         let reg = registry();
         let text = emit_stripped(&reg, "javascript", b"var x = a ? b : c;\n");
-        assert!(
-            text.contains('?'),
-            "#162: ternary must preserve '?', got: {text}"
-        );
+        assert!(text.contains('?'), "ternary must preserve '?', got: {text}");
     });
 }
-
-// ---------------------------------------------------------------
-// #163: JavaScript template literal mangled
-// ---------------------------------------------------------------
 
 #[test]
 fn js_template_literal_interpolation_inline() {
@@ -120,14 +93,10 @@ fn js_template_literal_interpolation_inline() {
         let text = emit_stripped(&reg, "javascript", b"var s = `hello ${name}`;\n");
         assert!(
             !text.contains("${\n") && !text.contains("${ "),
-            "#163: template interpolation must be inline, got: {text}"
+            "template interpolation must be inline, got: {text}"
         );
     });
 }
-
-// ---------------------------------------------------------------
-// #164: Julia function body emitted inline
-// ---------------------------------------------------------------
 
 #[test]
 #[cfg(feature = "lang-julia")]
@@ -149,14 +118,10 @@ fn julia_function_body_not_inline() {
             .count();
         assert_eq!(
             errors, 0,
-            "#164: re-parsed Julia should have 0 ERROR nodes, got {errors}\nemitted:\n{text}"
+            "re-parsed Julia should have 0 ERROR nodes, got {errors}\nemitted:\n{text}"
         );
     });
 }
-
-// ---------------------------------------------------------------
-// #165: Stan array declaration size split
-// ---------------------------------------------------------------
 
 #[test]
 #[cfg(feature = "lang-stan")]
@@ -167,17 +132,10 @@ fn stan_array_size_inside_declaration() {
         let bracket_pos = text.find('[');
         let semi_pos = text.find(';');
         if let (Some(bp), Some(sp)) = (bracket_pos, semi_pos) {
-            assert!(
-                bp < sp,
-                "#165: array size '[10]' must be before ';', got: {text}"
-            );
+            assert!(bp < sp, "array size '[10]' must be before ';', got: {text}");
         }
     });
 }
-
-// ---------------------------------------------------------------
-// #166: Stan function declaration parameter list
-// ---------------------------------------------------------------
 
 #[test]
 #[cfg(feature = "lang-stan")]
@@ -191,14 +149,10 @@ fn stan_function_params_inside_parens() {
         );
         assert!(
             !text.contains("sq() real x"),
-            "#166: function params must be inside parens, got: {text}"
+            "function params must be inside parens, got: {text}"
         );
     });
 }
-
-// ---------------------------------------------------------------
-// #167: Julia multi-argument macrocall
-// ---------------------------------------------------------------
 
 #[test]
 #[cfg(feature = "lang-julia")]
@@ -208,7 +162,57 @@ fn julia_macrocall_multi_arg_preserves_all() {
         let text = emit_stripped(&reg, "julia", b"@info \"msg\" foo bar\n");
         assert!(
             text.contains("foo") && text.contains("bar"),
-            "#167: multi-arg macrocall must preserve all args, got: {text}"
+            "multi-arg macrocall must preserve all args, got: {text}"
+        );
+    });
+}
+
+#[test]
+fn python_assignment_no_stray_colon() {
+    with_big_stack(|| {
+        let reg = registry();
+        let text = emit_stripped(&reg, "python", b"x = 1\n");
+        assert!(
+            !text.contains(": =") && !text.contains(":="),
+            "assignment must not have stray ':', got: {text}"
+        );
+        assert!(
+            text.contains("x = 1") || text.contains("x= 1") || text.contains("x =1"),
+            "assignment must contain 'x = 1', got: {text}"
+        );
+    });
+}
+
+#[test]
+#[cfg(feature = "lang-stan")]
+fn stan_vector_size_inside_brackets() {
+    with_big_stack(|| {
+        let reg = registry();
+        let text = emit_stripped(
+            &reg,
+            "stan",
+            b"data {\n  int N;\n  vector[N] y;\n}\nmodel { y ~ normal(0, 1); }\n",
+        );
+        assert!(
+            !text.contains("vector N"),
+            "vector size must be inside brackets, got: {text}"
+        );
+    });
+}
+
+#[test]
+#[cfg(feature = "lang-scheme")]
+fn scheme_emit_nonempty() {
+    with_big_stack(|| {
+        let reg = registry();
+        let text = emit_stripped(&reg, "scheme", b"(define (f x) (+ x 1))\n");
+        assert!(
+            !text.is_empty(),
+            "Scheme emit_pretty must produce non-empty output"
+        );
+        assert!(
+            text.contains("define"),
+            "Scheme output must contain 'define', got: {text}"
         );
     });
 }


### PR DESCRIPTION
## Summary

- Fix overly aggressive node-types.json subtype augmentation that caused Python assignments to emit stray `:`, Stan vector sizes to displace, and Scheme to produce empty output
- Remove issue-number references from doc comments and test assertions
- 3 new regression tests (Python assignment, Stan vector, Scheme emit)

## Test plan

- [x] 64 base + 11 feature-gated tests pass (1 `#[ignore]`)
- [x] `cargo fmt`, `cargo clippy -D warnings`
- [ ] Full CI

Closes #170, closes #171, closes #172