### PR TITLE
fix(emit_pretty): relocated-subtree separator (closes #202) + julia clause newline + ruby status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to panproto will be documented in this file.
 
+## [0.56.1] - 2026-06-18
+
+### Fixed
+
+- **`emit_pretty` no longer glues a relocated subtree onto its sibling** (`panproto-parse`): when a parsed subtree (e.g. a Python `class_definition`) is grafted onto a fresh schema beside another top-level statement, it keeps the `[start-byte, end-byte)` span it had in its original source. The byte-faithful replay path tiled that stale span and emitted the subtree as raw bytes, which bypasses the separator its new context needs: the class body's last token ran straight into the next `def` (`…(1 + 2)def f():`), invalid Python. The replay path now detects a relocated subtree (one whose recorded span is not contained by its new parent's) and restores a line break on each edge of the verbatim blob, keeping the body byte-faithful while preventing the glue. Line breaks are idempotent at a line start, and a freshly parsed schema (every child's span nested in its parent's) is never relocated, so the canonical corpus replay is byte-identical. Closes #202.
+- **De-novo emit keeps a julia `if`/`elseif`/`else` clause body on its own line** (`panproto-parse`): on the by-construction path (no layout fibre), a clause's body separator is the optional `_terminator` slot, whose newline form is a `\r?\n` pattern. The choice tie-break matches only string literals, never a pattern, so the slot fell through to `BLANK` and the body glued onto the keyword line (`elseif x < 0` ran into `-1`, re-lexing as one expression and dropping the clause's `block`). An optional separator CHOICE that offers a newline alternative now defers instead of forcing `BLANK`, so the existing pure-separator newline preference supplies the canonical newline. `;`-terminator / ASI slots are unaffected.
+
+### Changed
+
+- **`ruby` emit verification status is `Verified`** (`panproto-parse` test suite): `ruby` is in `VERIFIED_EMIT_PROTOCOLS` (its full upstream `test/corpus` round-trips under the strict oracle), so the status test now asserts `Verified` rather than the stale `Generic`.
+
 ## [0.56.0] - 2026-06-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "anyhow",
  "miette",
@@ -1962,7 +1962,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "ciborium",
  "git2",
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "divan",
  "insta",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "divan",
  "proptest",
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "chumsky",
  "divan",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "divan",
  "miette",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "divan",
  "git2",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "git2",
  "miette",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "cc",
  "divan",
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2203,7 +2203,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2307,7 +2307,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-jit"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "divan",
  "inkwell",
@@ -2318,7 +2318,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "divan",
  "insta",
@@ -2337,7 +2337,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "divan",
  "miette",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-llvm"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "divan",
  "inkwell",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "divan",
  "memchr",
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "blake3",
  "divan",
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "blake3",
  "divan",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-repl"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "miette",
  "panproto-gat",
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "divan",
  "miette",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "blake3",
  "divan",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.56.0"
+version = "0.56.1"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -105,29 +105,29 @@ tree-sitter = "0.26"
 tree-sitter-tags = "0.26"
 
 # Workspace crates
-panproto-gat = { version = "0.56.0", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.56.0", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.56.0", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.56.0", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.56.0", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.56.0", path = "crates/panproto-lens" }
-panproto-lens-dsl = { version = "0.56.0", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.56.0", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.56.0", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.56.0", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.56.0", path = "crates/panproto-core" }
-panproto-io = { version = "0.56.0", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.56.0", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.56.0", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.56.0", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.56.0", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.56.0", path = "crates/panproto-parse" }
-panproto-project = { version = "0.56.0", path = "crates/panproto-project" }
-panproto-git = { version = "0.56.0", path = "crates/panproto-git" }
-panproto-llvm = { version = "0.56.0", path = "crates/panproto-llvm", default-features = false }
-panproto-jit = { version = "0.56.0", path = "crates/panproto-jit" }
-panproto-xrpc = { version = "0.56.0", path = "crates/panproto-xrpc" }
-panproto-repl = { version = "0.56.0", path = "crates/panproto-repl" }
+panproto-gat = { version = "0.56.1", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.56.1", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.56.1", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.56.1", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.56.1", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.56.1", path = "crates/panproto-lens" }
+panproto-lens-dsl = { version = "0.56.1", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.56.1", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.56.1", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.56.1", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.56.1", path = "crates/panproto-core" }
+panproto-io = { version = "0.56.1", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.56.1", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.56.1", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.56.1", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.56.1", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.56.1", path = "crates/panproto-parse" }
+panproto-project = { version = "0.56.1", path = "crates/panproto-project" }
+panproto-git = { version = "0.56.1", path = "crates/panproto-git" }
+panproto-llvm = { version = "0.56.1", path = "crates/panproto-llvm", default-features = false }
+panproto-jit = { version = "0.56.1", path = "crates/panproto-jit" }
+panproto-xrpc = { version = "0.56.1", path = "crates/panproto-xrpc" }
+panproto-repl = { version = "0.56.1", path = "crates/panproto-repl" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.56.0
+version:            0.56.1
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/python/tests/test_native.py
+++ b/bindings/python/tests/test_native.py
@@ -1180,3 +1180,85 @@ class TestRepositoryDataAccess:
 
         # With no caller key, the source path is the key.
         assert repo.data_at("HEAD")[0]["key"] == str(data_file)
+
+
+# ---------------------------------------------------------------------------
+# emit_pretty: relocated (grafted) subtree separation
+# ---------------------------------------------------------------------------
+
+
+class TestEmitPrettyGraft:
+    """A parsed subtree grafted beside another statement must not concatenate."""
+
+    def test_grafted_class_separates_from_sibling(self) -> None:
+        import ast
+
+        reg = panproto.AstParserRegistry()
+        if "python" not in reg.protocol_names():
+            import pytest
+
+            pytest.skip("python grammar not built into this wheel")
+
+        proto = panproto.Protocol.from_theories(
+            name="python", schema_theory="python", obj_kinds=[]
+        )
+        src = (
+            b"class A:\n    def m(self):\n        return self.x.y(1 + 2)\n"
+            b"\ndef f():\n    return 2\n"
+        )
+        parsed = reg.parse_with_protocol("python", src, "src.py")
+
+        # Standalone round-trip is valid Python (the consistent case the fix
+        # must not disturb).
+        ast.parse(reg.emit_pretty("python", parsed).decode())
+
+        # Collect the class_definition subtree.
+        class_root = next(
+            v.id for v in parsed.vertices if v.kind == "class_definition"
+        )
+        kind_of = {v.id: v.kind for v in parsed.vertices}
+        seen = {class_root}
+        frontier = [class_root]
+        while frontier:
+            s = frontier.pop()
+            for e in parsed.edges:
+                if e.src == s and e.tgt not in seen:
+                    seen.add(e.tgt)
+                    frontier.append(e.tgt)
+
+        # Graft the class onto a fresh module beside a hand-built `def f()`.
+        sb = proto.schema()
+        sb.vertex("mod", "module")
+        id_map = {}
+        for i, old in enumerate(seen):
+            new = f"g_{i}"
+            id_map[old] = new
+            sb.vertex(new, kind_of[old])
+            for c in parsed.constraints_for(old):
+                sb.constraint(new, c.sort, c.value)
+        for e in parsed.edges:
+            if e.src in id_map and e.tgt in id_map:
+                sb.edge(id_map[e.src], id_map[e.tgt], e.kind)
+        sb.edge("mod", id_map[class_root], "child_of")
+
+        sb.vertex("f", "function_definition")
+        sb.vertex("f_name", "identifier")
+        sb.constraint("f_name", "literal-value", "f")
+        sb.vertex("f_params", "parameters")
+        sb.vertex("f_body", "block")
+        sb.vertex("f_ret", "return_statement")
+        sb.vertex("f_two", "integer")
+        sb.constraint("f_two", "literal-value", "2")
+        sb.edge("f_ret", "f_two", "child_of")
+        sb.edge("f_body", "f_ret", "child_of")
+        sb.edge("f", "f_name", "name")
+        sb.edge("f", "f_params", "parameters")
+        sb.edge("f", "f_body", "body")
+        sb.edge("mod", "f", "child_of")
+
+        out = reg.emit_pretty("python", sb.build()).decode()
+
+        # The grafted class no longer runs straight into the following def,
+        # and the whole module is valid Python.
+        assert ")def" not in out, out
+        ast.parse(out)

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.56.0",
+  "version": "0.56.1",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.56.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.56.1", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.56.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.56.1", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.56.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.56.1", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep doesn't
 # pin default-features.
-panproto-grammars = { version = "=0.56.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.56.1", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.56.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.56.1", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.56.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.56.1", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.56.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.56.1", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.56.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.56.1", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.56.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.56.1", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.56.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.56.1", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-parse/src/emit_pretty/complement.rs
+++ b/crates/panproto-parse/src/emit_pretty/complement.rs
@@ -547,6 +547,50 @@ pub(crate) fn vertex_has_byte_span(schema: &Schema, vertex_id: &panproto_gat::Na
     })
 }
 
+/// True iff `vertex_id`'s recorded `[start-byte, end-byte)` span is consistent
+/// with its CURRENT position: either the vertex is a structural root (no
+/// incoming edge) or some structural parent records a byte span that contains
+/// it. Returns `true` when consistency cannot be contradicted, so the layout
+/// fibre is trusted by default.
+///
+/// Every vertex the parse walker produces records a `start-byte` and `end-byte`
+/// from its node position, and a tree-sitter child's span always nests inside
+/// its parent's. So for a freshly parsed schema this holds for every vertex and
+/// the caller's behaviour is unchanged. It is contradicted only when a parsed
+/// subtree is RELOCATED (grafted) onto a different schema: the subtree keeps the
+/// span it had in its original source, but its new parent was built de-novo
+/// (records no span) or is a different node whose span does not contain the
+/// stale one. The verbatim replay path uses this to decide whether the recorded
+/// inter-token whitespace still describes the subtree's surroundings.
+pub(crate) fn byte_span_consistent_with_parent(
+    schema: &Schema,
+    vertex_id: &panproto_gat::Name,
+) -> bool {
+    let (Some(start), Some(end)) = (
+        byte_anchor(schema, vertex_id, "start-byte"),
+        byte_anchor(schema, vertex_id, "end-byte"),
+    ) else {
+        // No usable span to contradict: trust the fibre.
+        return true;
+    };
+    match schema.incoming.get(vertex_id) {
+        // Structural root (e.g. a standalone parsed module): trust its own span.
+        None => true,
+        Some(parents) if parents.is_empty() => true,
+        Some(parents) => parents.iter().any(|edge| {
+            match (
+                byte_anchor(schema, &edge.src, "start-byte"),
+                byte_anchor(schema, &edge.src, "end-byte"),
+            ) {
+                (Some(parent_start), Some(parent_end)) => {
+                    parent_start <= start && end <= parent_end
+                }
+                _ => false,
+            }
+        }),
+    }
+}
+
 /// Reconstruct the EXACT source bytes of the subtree rooted at `vertex_id`
 /// from the recorded layout fibre, returning `None` unless the reconstruction
 /// is provably complete (tiles the root's `[start-byte, end-byte)` span with no

--- a/crates/panproto-parse/src/emit_pretty/review.rs
+++ b/crates/panproto-parse/src/emit_pretty/review.rs
@@ -28,19 +28,19 @@ use super::{
     ChildCursor, EMIT_DEPTH, EMIT_MU_FRAMES, Edge, Grammar, Output, ParseError, Production, Schema,
     Token, TokenRole, accepts_first_edge, alias_content_is_terminal_pattern,
     aliased_source_literals, alt_satisfies_field_token_restrictions,
-    alt_satisfies_pre_alias_constraints, children_for, classify_seq_positions, clear_field_context,
-    collect_field_names, collect_inner_field_names_expanded, contains_newline_pattern,
-    current_field_context, first_unconsumed_target_fingerprint, has_field_in,
-    has_relevant_constraint, has_repeat_in, is_blank_line_rule, is_connector_punctuation,
-    is_immediate_token, is_newline_alt, is_newline_like_pattern, is_no_space_external,
-    is_whitespace_external, is_whitespace_only_pattern, is_word_like, leaf_terminal_role,
-    left_recursive_alts, literal_strings, literal_value, mandatory_field_names,
-    member_has_leading_bracket, pattern_absorbs_leading_space, placeholder_for_pattern,
-    pre_alias_symbol, prec_value, push_field_context, reconstruct_subtree_bytes,
-    reduces_to_immediate_token, referenced_symbols, repeat_body_is_whole_vertex_item,
-    repeat_has_bracket_keyed_member, seq_bracket_triggers_indent, seq_open_bracket_index,
-    unbounded_negated_class, unwrap_prec, unwrap_to_string, vertex_has_byte_span, vertex_id_kind,
-    yield_of_production,
+    alt_satisfies_pre_alias_constraints, byte_span_consistent_with_parent, children_for,
+    classify_seq_positions, clear_field_context, collect_field_names,
+    collect_inner_field_names_expanded, contains_newline_pattern, current_field_context,
+    first_unconsumed_target_fingerprint, has_field_in, has_relevant_constraint, has_repeat_in,
+    is_blank_line_rule, is_connector_punctuation, is_immediate_token, is_newline_alt,
+    is_newline_like_pattern, is_no_space_external, is_whitespace_external,
+    is_whitespace_only_pattern, is_word_like, leaf_terminal_role, left_recursive_alts,
+    literal_strings, literal_value, mandatory_field_names, member_has_leading_bracket,
+    pattern_absorbs_leading_space, placeholder_for_pattern, pre_alias_symbol, prec_value,
+    push_field_context, reconstruct_subtree_bytes, reduces_to_immediate_token, referenced_symbols,
+    repeat_body_is_whole_vertex_item, repeat_has_bracket_keyed_member, seq_bracket_triggers_indent,
+    seq_open_bracket_index, unbounded_negated_class, unwrap_prec, unwrap_to_string,
+    vertex_has_byte_span, vertex_id_kind, yield_of_production,
 };
 
 pub(crate) fn collect_roots(schema: &Schema) -> Vec<&panproto_gat::Name> {
@@ -484,7 +484,23 @@ pub(crate) fn emit_vertex(
     // role table got wrong, never corrupt one it got right.
     if vertex_has_byte_span(schema, vertex_id) {
         if let Some(bytes) = reconstruct_subtree_bytes(schema, vertex_id) {
+            // A RELOCATED subtree (grafted under a parent that does not contain
+            // its recorded span) lost the separators that, in its original
+            // source, lived in the surrounding parent's interstitials. Restore a
+            // line break on each edge so the byte-faithful body cannot glue onto
+            // an adjacent sibling (issue #202: a grafted Python `class` running
+            // into the next `def`). Line breaks are idempotent at a line start,
+            // so a body that already ends in a newline gains none; and a freshly
+            // parsed schema (every child's span nested in its parent's) is never
+            // relocated, so this leaves the canonical replay byte-identical.
+            let relocated = !byte_span_consistent_with_parent(schema, vertex_id);
+            if relocated {
+                out.newline();
+            }
             out.verbatim(&bytes);
+            if relocated {
+                out.newline();
+            }
             return Ok(());
         }
     }
@@ -2233,7 +2249,16 @@ pub(crate) fn emit_aliased_child(
     // byte anchors) and can never corrupt a boundary the role table got right.
     if vertex_has_byte_span(schema, child_id) {
         if let Some(bytes) = reconstruct_subtree_bytes(schema, child_id) {
+            // Restore a line break on each edge of a relocated aliased subtree;
+            // see the matching guard in `emit_vertex` for the rationale.
+            let relocated = !byte_span_consistent_with_parent(schema, child_id);
+            if relocated {
+                out.newline();
+            }
             out.verbatim(&bytes);
+            if relocated {
+                out.newline();
+            }
             return Ok(());
         }
     }

--- a/crates/panproto-parse/src/emit_pretty/unify.rs
+++ b/crates/panproto-parse/src/emit_pretty/unify.rs
@@ -43,7 +43,7 @@
 //! stealing a child (`int_literal`) that belongs to a later mandatory
 //! member, while still admitting genuine supertype dispatch.
 
-use super::{Grammar, Production, collect_field_names};
+use super::{Grammar, Production, collect_field_names, is_newline_alt};
 
 /// Does an abstract child of surface kind `k` satisfy a concrete
 /// grammar `SYMBOL`/`ALIAS` target named `name`?
@@ -1171,6 +1171,18 @@ pub(crate) fn select_choice_with_trace(
             return winner;
         }
     }
+    // A newline-bearing terminator slot is invisible to the literal tie-break:
+    // `alt_literals_resolved` collects only STRING literals, so a hidden
+    // `_terminator` whose newline form is a PATTERN (`\r?\n`) contributes no
+    // literal and scores zero overlap, even though the parser recorded the
+    // newline it emitted as a bare-newline trace token. When this is an
+    // optional separator slot, the trace attests a bare newline, and a
+    // candidate IS the newline alternative, prefer it over `BLANK` so a clause
+    // body lands on its own line (julia `if`/`elseif`/`else`: without it
+    // `elseif x < 0` glues onto its body `-1`, re-lexing as one expression and
+    // dropping the clause's block). Gated on the trace genuinely containing a
+    // bare newline, so `;`-terminator / ASI slots (recorded as `T;`, never a
+    // bare newline) keep their existing resolution.
     // No variant tag resolved the tie and no candidate consumes a child
     // (`best_len == 0`): this is an OPTIONAL production — an optional
     // token / separator with nothing structural demanding it. The
@@ -1180,12 +1192,28 @@ pub(crate) fn select_choice_with_trace(
     // this only fires for genuinely-absent optionals (kotlin's optional
     // `;` / trailing `,`, which the lossy heuristics otherwise emit
     // spuriously on a complement-free schema).
+    //
+    // EXCEPTION: when a candidate is a newline terminator (julia
+    // `if`/`elseif`/`else` body separator, `_terminator = CHOICE[\r?\n, ;]`),
+    // do NOT short-circuit to `BLANK`. The emitted newline is not recorded as
+    // a trace token (it rode the interstitial fibre, stripped on this path),
+    // so the tie-break above never sees it; defaulting to `BLANK` would glue
+    // the clause body onto the keyword/condition line and re-lex it as one
+    // expression, dropping the clause's `block`. Defer (return `None`) so the
+    // caller's downstream pure-separator newline preference — which fires
+    // exactly when a separator is structurally needed and every alternative
+    // is non-consuming — supplies the canonical newline.
     if best_len == 0 {
-        if let Some(b) = alternatives
+        let has_newline_alt = cands
             .iter()
-            .position(|a| matches!(a, Production::Blank))
-        {
-            return Some(b);
+            .any(|&i| is_newline_alt(grammar, &alternatives[i]));
+        if !has_newline_alt {
+            if let Some(b) = alternatives
+                .iter()
+                .position(|a| matches!(a, Production::Blank))
+            {
+                return Some(b);
+            }
         }
     }
     None

--- a/crates/panproto-parse/tests/emit_relocated_subtree.rs
+++ b/crates/panproto-parse/tests/emit_relocated_subtree.rs
@@ -1,0 +1,89 @@
+//! Regression (issue #202): a parsed subtree relocated into a new context
+//! must not replay its stale byte span verbatim and concatenate onto its new
+//! sibling.
+//!
+//! When a parsed `class_definition` is grafted onto a fresh schema beside a
+//! sibling statement, the class keeps the `[start-byte, end-byte)` span it
+//! had in its original source. The verbatim replay path tiled that stale span
+//! perfectly and emitted the class as raw bytes, which bypasses the
+//! inter-statement separator the relocated context needs: the class body's
+//! last token ran straight into the next `def` (`…(1 + 2)def f():`), invalid
+//! Python. The fix declines verbatim replay when a vertex's recorded span is
+//! not contained by its parent's, falling back to the role-table walk that
+//! inserts the grammar-default separator.
+//!
+//! This test reproduces the "relocated" condition minimally: it parses a real
+//! module, then drops the module root's byte span so its children become
+//! subtrees whose parent no longer contains them, exactly what a graft does.
+
+#![cfg(all(feature = "grammars", feature = "lang-python"))]
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use panproto_parse::ParserRegistry;
+
+fn with_big_stack<F: FnOnce() + Send + 'static>(inner: F) {
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(inner)
+        .expect("spawn")
+        .join()
+        .expect("worker panicked");
+}
+
+#[test]
+fn relocated_subtree_separates_from_sibling() {
+    with_big_stack(|| {
+        let reg = ParserRegistry::new();
+        let src =
+            b"class A:\n    def m(self):\n        return self.x.y(1 + 2)\n\ndef f():\n    return 2\n";
+        let parsed = reg
+            .parse_with_protocol("python", src, "src.py")
+            .expect("parse");
+
+        // Standalone round-trip stays byte-faithful (the consistent case the
+        // fix must not disturb): every vertex's span nests in its parent's.
+        let standalone = reg
+            .emit_pretty_with_protocol("python", &parsed)
+            .expect("emit standalone");
+        let standalone = String::from_utf8_lossy(&standalone).into_owned();
+        assert!(
+            standalone.contains(")\n\ndef f") || standalone.contains(")\ndef f"),
+            "standalone emit lost the class/def separator: {standalone:?}"
+        );
+
+        // Relocate: drop the root module's byte span. Its children keep their
+        // own (now stale) spans, so the parent no longer contains them.
+        let root = parsed
+            .vertices
+            .keys()
+            .find(|id| parsed.incoming.get(*id).is_none_or(|e| e.is_empty()))
+            .expect("a structural root")
+            .clone();
+        let mut relocated = parsed.clone();
+        let cs = relocated
+            .constraints
+            .get_mut(&root)
+            .expect("root constraints");
+        cs.retain(|c| c.sort.as_ref() != "start-byte" && c.sort.as_ref() != "end-byte");
+
+        let out = reg
+            .emit_pretty_with_protocol("python", &relocated)
+            .expect("emit relocated");
+        let text = String::from_utf8_lossy(&out).into_owned();
+
+        // The class must not run straight into the following def.
+        assert!(
+            !text.contains(")def"),
+            "grafted class concatenated onto the next statement: {text:?}"
+        );
+        assert!(
+            text.contains("def f"),
+            "relocated def missing from output: {text:?}"
+        );
+        // A separator (newline) now precedes the top-level def.
+        assert!(
+            text.contains("\ndef f"),
+            "no separator before the relocated def: {text:?}"
+        );
+    });
+}

--- a/crates/panproto-parse/tests/emit_verification_status.rs
+++ b/crates/panproto-parse/tests/emit_verification_status.rs
@@ -90,15 +90,15 @@ fn verified_for_quivers_javascript_backend() {
     );
 }
 
-/// Protocols whose grammar is registered but whose `emit_pretty` has
-/// no per-language test in panproto's suite. The API must report
-/// `Generic` so downstream tooling can opt into the safety check.
+/// `ruby` is corpus-verified: its entire upstream `test/corpus` round-trips
+/// under the strict emit oracle, so it is in `VERIFIED_EMIT_PROTOCOLS` and the
+/// API reports `Verified`.
 #[test]
 #[cfg(feature = "lang-ruby")]
-fn generic_for_untested_ruby() {
+fn verified_for_ruby() {
     let reg = ParserRegistry::new();
     assert_eq!(
         reg.emit_verification_status("ruby"),
-        EmitVerificationStatus::Generic
+        EmitVerificationStatus::Verified
     );
 }


### PR DESCRIPTION
## Summary

Fixes #202 (the reported bug) plus two pre-existing emit-test failures surfaced by the full `--all-features` corpus sweep. Branched off `main`. Release **0.56.1** (patch; no public API change). #203 was not actionable (the QVR grammar commit is local-only/unpushed in `FACTSlab/quivers`, not on the public repo).

### #202 — relocated (grafted) subtree separator

When a parsed subtree (e.g. a Python `class_definition`) is grafted onto a fresh schema beside another top-level statement, it keeps the `[start-byte, end-byte)` span from its original source. The byte-faithful replay path tiled that stale span and emitted the subtree verbatim, bypassing the separator its new context needs: the class body's last token ran into the next `def` (`…(1 + 2)def f():`), invalid Python. The replay path now detects a **relocated** subtree (recorded span not contained by its new parent's — impossible for a freshly parsed schema, true only for grafts) and restores a line break on each edge of the verbatim blob. Line breaks are idempotent at a line start, so the body stays byte-faithful and the canonical corpus replay is byte-identical.

### julia `if`/`elseif`/`else` clause newline (pre-existing)

On the de-novo path, a clause body's separator is the optional `_terminator` slot whose newline form is a `\r?\n` **pattern**. The choice tie-break matches only string literals, never patterns, so the slot fell through to `BLANK` and the body glued onto the keyword line (`elseif x < 0` ran into `-1`, re-lexing as one expression and dropping the clause's `block`). An optional separator CHOICE offering a newline alternative now **defers** instead of forcing `BLANK`, so the existing pure-separator newline preference supplies the canonical newline. `;`-terminator / ASI slots (recorded as `T;`, never a bare newline) are unaffected.

### ruby emit status (pre-existing, stale test)

`ruby` is in `VERIFIED_EMIT_PROTOCOLS` (its full upstream `test/corpus` round-trips under the strict oracle). The status test asserted the stale `Generic`; it now asserts `Verified`.

### Deferred: bash `case` de-novo `;;` over-emission → #204

The de-novo bash `case` emit over-emits `;;` (a single recorded `ptrace` terminator matched at multiple separator CHOICE sites; the last `case_item` records it only as `ptrace`, not `field:`). The complete fix is a per-vertex ptrace-literal budget threaded through the emit walk — a wider, separately-validated change. Filed as **#204**; this PR does not touch it.

## Testing

- **Full `--all-features` corpus sweep** (every vendored grammar's entire `test/corpus` under the strict oracle, all emit tests, the 3 slow corpus gates): **341/342 pass**, the only failure being the pre-existing `bash::case_esac` (#204). Confirms #202 + julia + ruby cause **zero regressions** (verified against a clean `origin/main` worktree: julia/ruby/case_esac all fail identically there; the 3 corpus gates pass).
- New Rust test `emit_relocated_subtree` (relocated subtree separates; standalone round-trip unchanged).
- New Python test `TestEmitPrettyGraft` (the issue's exact graft reproduction; `ast.parse` succeeds).
- `fmt --check`, `clippy -D warnings`, `cargo doc -D warnings` (panproto-parse); Python suite 133 passed.