### PR TITLE
fix(parse): surface tree-sitter MISSING anonymous tokens as zero-width markers

### DIFF
--- a/crates/panproto-parse/src/walker.rs
+++ b/crates/panproto-parse/src/walker.rs
@@ -171,6 +171,11 @@ impl<'a> AstWalker<'a> {
         parent_vertex_id: Option<&str>,
     ) -> Result<SchemaBuilder, ParseError> {
         // Skip anonymous tokens (punctuation, keywords like `{`, `}`, `,`, etc.).
+        // Error-recovery MISSING anonymous tokens (a zero-width `}`, `)`, `,`,
+        // or keyword tree-sitter *inserts* to recover) are anonymous too, so
+        // they would be dropped here; they are instead surfaced in
+        // `walk_children_with_interstitials`, which scans every node's children
+        // for them before the named-child walk (which also skips them).
         if !node.is_named() {
             return Ok(builder);
         }
@@ -361,6 +366,44 @@ impl<'a> AstWalker<'a> {
         Ok(builder)
     }
 
+    /// Emit a zero-width, `ERROR`-kinded marker vertex for a tree-sitter
+    /// error-recovery MISSING anonymous token, attached to `parent_vertex_id`.
+    ///
+    /// The marker is kinded like a genuine `ERROR` node where the protocol or
+    /// theory admits that kind, else the closed-protocol `node` fallback. Its
+    /// zero-width span (`start == end`, as for any inserted token) and its
+    /// `missing` constraint (recording the elided token) let a downstream
+    /// schema walker distinguish a recovered-incomplete parse from a complete
+    /// one; a missing *named* token is already surfaced as a zero-width vertex
+    /// by the normal walk, so this only closes the gap for anonymous ones.
+    fn emit_missing_marker(
+        &self,
+        missing: tree_sitter::Node<'_>,
+        mut builder: SchemaBuilder,
+        id_gen: &mut IdGenerator,
+        parent_vertex_id: &str,
+    ) -> Result<SchemaBuilder, ParseError> {
+        let admits_error = self.protocol.obj_kinds.is_empty()
+            || self.protocol.obj_kinds.iter().any(|k| k == "ERROR")
+            || self.theory_meta.vertex_kinds.iter().any(|k| k == "ERROR");
+        let marker_kind = if admits_error { "ERROR" } else { "node" };
+        let vertex_id = id_gen.anonymous_id();
+        builder = builder.vertex(&vertex_id, marker_kind, None).map_err(|e| {
+            ParseError::SchemaConstruction {
+                reason: format!("missing-token marker '{vertex_id}': {e}"),
+            }
+        })?;
+        builder = builder
+            .edge(parent_vertex_id, &vertex_id, "child_of", None)
+            .map_err(|e| ParseError::SchemaConstruction {
+                reason: format!("missing-token edge {parent_vertex_id} -> {vertex_id}: {e}"),
+            })?;
+        builder = builder.constraint(&vertex_id, "start-byte", &missing.start_byte().to_string());
+        builder = builder.constraint(&vertex_id, "end-byte", &missing.end_byte().to_string());
+        builder = builder.constraint(&vertex_id, "missing", missing.kind());
+        Ok(builder)
+    }
+
     /// Walk named children, capturing interstitial text between them.
     ///
     /// Also computes a `chose-alt-fingerprint` constraint by trimming
@@ -412,6 +455,21 @@ impl<'a> AstWalker<'a> {
             }
             builder = self.walk_node(*child, builder, id_gen, Some(vertex_id))?;
             prev_end = child.end_byte();
+        }
+
+        // Surface error-recovery MISSING anonymous tokens among this node's
+        // direct children. Tree-sitter inserts a zero-width MISSING token (a
+        // `}`, `)`, `,`, or keyword) to recover from an incomplete construct;
+        // because it is anonymous it is skipped by the named-children walk
+        // above, so a recovered-incomplete parse would otherwise carry no ERROR
+        // vertex and no zero-width vertex — indistinguishable from a complete
+        // parse. Emit a marker for each so schema walkers that reject ERROR /
+        // zero-width vertices detect the recovery.
+        let missing_cursor = &mut node.walk();
+        for child in node.children(missing_cursor) {
+            if child.is_missing() && !child.is_named() {
+                builder = self.emit_missing_marker(child, builder, id_gen, vertex_id)?;
+            }
         }
 
         // Trailing interstitial after the last child.

--- a/crates/panproto-parse/tests/qvr_error_recovery.rs
+++ b/crates/panproto-parse/tests/qvr_error_recovery.rs
@@ -1,0 +1,81 @@
+//! Error-recovery MISSING anonymous tokens surface as schema markers.
+//!
+//! When tree-sitter recovers from an incomplete construct by *inserting* a
+//! zero-width MISSING token, and that token is anonymous (a `]`, `}`, `)`,
+//! `,`, or keyword), the walker used to drop it silently: the recovered parse
+//! carried no `ERROR` vertex and no zero-width vertex, so it was
+//! indistinguishable from a complete parse and a downstream walker validating
+//! input could not reject it. The walker now surfaces each such token as a
+//! zero-width, `ERROR`-kinded marker vertex carrying a `missing` constraint.
+
+#![cfg(all(feature = "grammars", feature = "lang-qvr"))]
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use panproto_parse::ParserRegistry;
+
+#[test]
+fn missing_anonymous_token_surfaces_zero_width_marker() {
+    // The dropped `]` after `[role=latent` makes tree-sitter recover by
+    // inserting a zero-width MISSING `]` (an anonymous token).
+    let registry = ParserRegistry::new();
+    let schema = registry
+        .parse_with_protocol(
+            "qvr",
+            b"object State : FinSet 8\nmorphism t : State -> State [role=latent\n",
+            "recovered.qvr",
+        )
+        .expect("qvr parser recovers from the dropped `]`");
+
+    // The recovery is legible: a vertex carrying a `missing` constraint that
+    // records the elided token.
+    let marker = schema
+        .vertices
+        .keys()
+        .find(|vid| {
+            schema
+                .constraints
+                .get(*vid)
+                .is_some_and(|cs| cs.iter().any(|c| &*c.sort == "missing"))
+        })
+        .expect("a dropped anonymous token must surface a `missing` marker vertex");
+
+    let cs = schema
+        .constraints
+        .get(marker)
+        .expect("marker has constraints");
+    let get = |sort: &str| {
+        cs.iter()
+            .find(|c| &*c.sort == sort)
+            .map(|c| c.value.clone())
+    };
+    // Zero-width span (start == end) is the signal downstream walkers key on;
+    // the recorded token makes it distinguishable from a genuine ERROR subtree.
+    assert_eq!(get("start-byte"), get("end-byte"), "marker is zero-width");
+    assert_eq!(
+        get("missing").as_deref(),
+        Some("]"),
+        "records the elided token"
+    );
+    // The qvr protocol admits the ERROR kind, so the marker is also caught by a
+    // downstream `kind == "ERROR"` rejection, not only a zero-width check.
+    assert_eq!(&*schema.vertices[marker].kind, "ERROR");
+}
+
+#[test]
+fn complete_parse_has_no_missing_marker() {
+    // The well-formed counterpart must NOT carry a recovery marker, so the
+    // marker is a true positive rather than always-on noise.
+    let registry = ParserRegistry::new();
+    let schema = registry
+        .parse_with_protocol(
+            "qvr",
+            b"object State : FinSet 8\nmorphism t : State -> State [role=latent]\n",
+            "complete.qvr",
+        )
+        .expect("well-formed qvr parses");
+    let has_marker = schema
+        .constraints
+        .values()
+        .any(|cs| cs.iter().any(|c| &*c.sort == "missing"));
+    assert!(!has_marker, "a complete parse carries no `missing` marker");
+}


### PR DESCRIPTION
## Summary

Closes #214. When tree-sitter recovers from an incomplete construct by *inserting* a zero-width MISSING token, and that token is **anonymous** (a `]`, `}`, `)`, `,`, or keyword), the walker dropped it silently. The recovered parse then carried no `ERROR` vertex and no zero-width vertex — indistinguishable from a complete parse — so a downstream walker validating input (e.g. quivers rejecting ERROR / zero-width vertices) had a blind spot for unbalanced brackets/braces.

## Changes

- `crates/panproto-parse/src/walker.rs`: the named-children walk (`walk_children_with_interstitials`) skips anonymous children, so it now scans every node's direct children for MISSING anonymous tokens and emits a marker for each via a new `emit_missing_marker` helper — a zero-width vertex kinded like a genuine `ERROR` node (or the closed-protocol `node` fallback) with a `missing` constraint recording the elided token. A missing *named* token is already surfaced as a zero-width vertex, so this only closes the gap for anonymous ones.

## Test plan

- New `qvr_error_recovery.rs`: a dropped `]` after `[role=latent` (confirmed via a raw-tree probe to make tree-sitter insert a MISSING `]`) produces a zero-width `ERROR`-kinded marker with `missing = "]"`; the well-formed counterpart produces none (true-positive, not always-on).
- `cargo nextest run -p panproto-parse` (group-core, incl. the byte-faithful `emit_corpus_audit` round-trips): **123/123 pass** — complete sources have no missing tokens, so markers never appear and round-trips are unchanged.
- `cargo clippy -p panproto-parse --all-targets -- -D warnings` clean (Rust 1.97).

## Type of change

- [x] Bug fix (non-breaking)

## Affected surfaces

- [x] Rust crates (`crates/`) — `panproto-parse`

## Linked issues

- Closes #214