### PR TITLE
feat(gat): refined scalar value kinds (date-time, date, time, decimal, uuid)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to panproto will be documented in this file.
 
+## [0.58.0] - 2026-07-14
+
+### Added
+
+- **Refined scalar value kinds** (`panproto-gat`): `ValueKind` gains `DateTime`, `Date`, `Time`, `Decimal`, and `Uuid`, each with a canonical name (`date-time`, `date`, `time`, `decimal`, `uuid`). A record-to-theory encoder can now recover a datetime, date, time, decimal, or uuid field as such instead of collapsing it to `Str`; the Python SDK picks the kinds up automatically because its name-to-kind lookup is driven by `ValueKind::as_str`, and the Haskell and TypeScript bindings gain the variants for parity. The new variants are declared after `Any` so the existing kinds' discriminants are preserved. Closes #190.
+
+### Fixed
+
+- **Tree-sitter MISSING anonymous tokens surface as recovery markers** (`panproto-parse`): when tree-sitter recovers from an incomplete construct by inserting a zero-width MISSING token that is anonymous (a `]`, `}`, `)`, `,`, or keyword), the walker dropped it silently, leaving a recovered-incomplete parse with no `ERROR` vertex and no zero-width vertex — indistinguishable from a complete parse. The walker now scans every node's children for such tokens and emits a zero-width, `ERROR`-kinded marker vertex carrying a `missing` constraint, so a schema walker that rejects `ERROR` / zero-width vertices detects the recovery. Closes #214.
+- **De-novo bash `case` emits one `;;` per item** (`panproto-parse`): on the by-construction emit path a `case`/`esac` over-emitted the `;;` terminator (three per case item) and dropped the newlines between items, so the re-parse gained an `ERROR` node. A per-vertex `ptrace`-literal budget caps each recorded separator literal at its true source multiplicity across a single vertex's emit walk, so the single `;;` is matched once. Closes #204.
+
 ## [0.57.0] - 2026-07-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "miette",
@@ -1924,7 +1924,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "ciborium",
  "git2",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "divan",
  "insta",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-dsl-eval"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "nickel-lang",
  "serde",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "divan",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "chumsky",
  "divan",
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "divan",
  "miette",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "divan",
  "git2",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "git2",
  "miette",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "cc",
  "divan",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2206,7 +2206,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2247,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "divan",
  "insta",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "divan",
  "miette",
@@ -2311,7 +2311,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2328,7 +2328,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "divan",
  "memchr",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "divan",
  "miette",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.57.0"
+version = "0.58.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -107,27 +107,27 @@ tree-sitter = "0.26"
 tree-sitter-tags = "0.26"
 
 # Workspace crates
-panproto-gat = { version = "0.57.0", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.57.0", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.57.0", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.57.0", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.57.0", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.57.0", path = "crates/panproto-lens" }
-panproto-dsl-eval = { version = "0.57.0", path = "crates/panproto-dsl-eval" }
-panproto-lens-dsl = { version = "0.57.0", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.57.0", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.57.0", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.57.0", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.57.0", path = "crates/panproto-core" }
-panproto-io = { version = "0.57.0", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.57.0", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.57.0", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.57.0", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.57.0", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.57.0", path = "crates/panproto-parse" }
-panproto-project = { version = "0.57.0", path = "crates/panproto-project" }
-panproto-git = { version = "0.57.0", path = "crates/panproto-git" }
-panproto-xrpc = { version = "0.57.0", path = "crates/panproto-xrpc" }
+panproto-gat = { version = "0.58.0", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.58.0", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.58.0", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.58.0", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.58.0", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.58.0", path = "crates/panproto-lens" }
+panproto-dsl-eval = { version = "0.58.0", path = "crates/panproto-dsl-eval" }
+panproto-lens-dsl = { version = "0.58.0", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.58.0", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.58.0", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.58.0", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.58.0", path = "crates/panproto-core" }
+panproto-io = { version = "0.58.0", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.58.0", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.58.0", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.58.0", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.58.0", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.58.0", path = "crates/panproto-parse" }
+panproto-project = { version = "0.58.0", path = "crates/panproto-project" }
+panproto-git = { version = "0.58.0", path = "crates/panproto-git" }
+panproto-xrpc = { version = "0.58.0", path = "crates/panproto-xrpc" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:            0.57.0
+version:            0.58.0
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/haskell/src/Panproto/Gat.hs
+++ b/bindings/haskell/src/Panproto/Gat.hs
@@ -168,6 +168,11 @@ data ValueKind
     | Bytes
     | Token
     | Null
+    | DateTime
+    | Date
+    | Time
+    | Decimal
+    | Uuid
     | Any
     deriving stock (Eq, Show, Generic, Bounded, Enum)
     deriving anyclass (NFData, Hashable, ToJSON, FromJSON)
@@ -1477,6 +1482,11 @@ valueKindTag = \case
     Bytes -> "Bytes"
     Token -> "Token"
     Null -> "Null"
+    DateTime -> "DateTime"
+    Date -> "Date"
+    Time -> "Time"
+    Decimal -> "Decimal"
+    Uuid -> "Uuid"
     Any -> "Any"
 
 valueKindTags :: [(Text, ValueKind)]

--- a/bindings/python-grammars-all/pyproject.toml
+++ b/bindings/python-grammars-all/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.57,<0.58",
+    "panproto>=0.58,<0.59",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-data/pyproject.toml
+++ b/bindings/python-grammars-data/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.57,<0.58",
+    "panproto>=0.58,<0.59",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-devops/pyproject.toml
+++ b/bindings/python-grammars-devops/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.57,<0.58",
+    "panproto>=0.58,<0.59",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-functional/pyproject.toml
+++ b/bindings/python-grammars-functional/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # companion via the entry point declared below; without panproto
     # installed there is no consumer for the grammars this package
     # ships.
-    "panproto>=0.57,<0.58",
+    "panproto>=0.58,<0.59",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-jvm/pyproject.toml
+++ b/bindings/python-grammars-jvm/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.57,<0.58",
+    "panproto>=0.58,<0.59",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-mobile/pyproject.toml
+++ b/bindings/python-grammars-mobile/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.57,<0.58",
+    "panproto>=0.58,<0.59",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-music/pyproject.toml
+++ b/bindings/python-grammars-music/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.57,<0.58",
+    "panproto>=0.58,<0.59",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-scripting/pyproject.toml
+++ b/bindings/python-grammars-scripting/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.57,<0.58",
+    "panproto>=0.58,<0.59",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-systems/pyproject.toml
+++ b/bindings/python-grammars-systems/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.57,<0.58",
+    "panproto>=0.58,<0.59",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-web/pyproject.toml
+++ b/bindings/python-grammars-web/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.57,<0.58",
+    "panproto>=0.58,<0.59",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/bindings/typescript/src/types.ts
+++ b/bindings/typescript/src/types.ts
@@ -635,7 +635,20 @@ export interface WasmExports {
 // ---------------------------------------------------------------------------
 
 /** Primitive value kind. */
-export type ValueKind = 'bool' | 'int' | 'float' | 'str' | 'bytes' | 'token' | 'null' | 'any';
+export type ValueKind =
+  | 'bool'
+  | 'int'
+  | 'float'
+  | 'str'
+  | 'bytes'
+  | 'token'
+  | 'null'
+  | 'datetime'
+  | 'date'
+  | 'time'
+  | 'decimal'
+  | 'uuid'
+  | 'any';
 
 /** Sort kind classification. */
 export type SortKind =

--- a/crates/panproto-gat/src/sort.rs
+++ b/crates/panproto-gat/src/sort.rs
@@ -665,6 +665,19 @@ pub enum ValueKind {
     Null,
     /// Any value kind (polymorphic).
     Any,
+    /// Refined string: an ISO 8601 date-time (`2026-07-14T09:47:12Z`).
+    ///
+    /// The refined scalar kinds are declared after `Any` so the discriminants
+    /// of the original kinds are preserved when new refinements are appended.
+    DateTime,
+    /// Refined string: an ISO 8601 calendar date (`2026-07-14`).
+    Date,
+    /// Refined string: an ISO 8601 wall-clock time (`09:47:12`).
+    Time,
+    /// Refined numeric: an exact base-10 decimal (no binary float rounding).
+    Decimal,
+    /// Refined string: an RFC 4122 UUID.
+    Uuid,
 }
 
 impl ValueKind {
@@ -679,6 +692,11 @@ impl ValueKind {
             Self::Bytes => "bytes",
             Self::Token => "token",
             Self::Null => "null",
+            Self::DateTime => "date-time",
+            Self::Date => "date",
+            Self::Time => "time",
+            Self::Decimal => "decimal",
+            Self::Uuid => "uuid",
             Self::Any => "any",
         }
     }
@@ -703,6 +721,11 @@ impl ValueKind {
                 | ValueKind::Bytes
                 | ValueKind::Token
                 | ValueKind::Null
+                | ValueKind::DateTime
+                | ValueKind::Date
+                | ValueKind::Time
+                | ValueKind::Decimal
+                | ValueKind::Uuid
                 | ValueKind::Any => {}
             }
         }
@@ -714,6 +737,11 @@ impl ValueKind {
             ValueKind::Bytes,
             ValueKind::Token,
             ValueKind::Null,
+            ValueKind::DateTime,
+            ValueKind::Date,
+            ValueKind::Time,
+            ValueKind::Decimal,
+            ValueKind::Uuid,
             ValueKind::Any,
         ];
         ALL
@@ -1413,6 +1441,29 @@ mod tests {
         let lhs = vec![SortParam::new("a", "Ob"), SortParam::new("b", "Ob")];
         let rhs = vec![SortParam::new("p", "Ob"), SortParam::new("q", "Ob")];
         assert!(sort_params_equivalent_modulo_rename(&lhs, &rhs));
+    }
+
+    #[test]
+    fn refined_value_kinds_are_distinct_and_named() {
+        // A record-to-theory encoder must be able to recover a
+        // `datetime` / `date` / `time` / `decimal` / `uuid` field as such
+        // rather than as a plain string: the refined scalar kinds carry a
+        // distinct identity and a canonical name, and appear in `all()` so
+        // exhaustive consumers (sample registries, coverage checks) see them.
+        for (kind, name) in [
+            (ValueKind::DateTime, "date-time"),
+            (ValueKind::Date, "date"),
+            (ValueKind::Time, "time"),
+            (ValueKind::Decimal, "decimal"),
+            (ValueKind::Uuid, "uuid"),
+        ] {
+            assert_ne!(kind, ValueKind::Str, "{kind:?} must not collapse to Str");
+            assert_eq!(kind.as_str(), name);
+            assert!(
+                ValueKind::all().contains(&kind),
+                "{kind:?} missing from all()"
+            );
+        }
     }
 
     #[test]

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.57.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.58.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.57.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.58.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.57.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.58.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.57.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.58.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.57.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.58.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.57.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.58.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.57.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.58.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.57.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.58.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.57.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.58.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.57.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.58.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-lens/src/coercion_laws.rs
+++ b/crates/panproto-lens/src/coercion_laws.rs
@@ -432,6 +432,43 @@ impl CoercionSampleRegistry {
                 Literal::Str("ns:name".to_owned()),
             ],
         );
+        // Refined scalars sample as their canonical string / decimal forms.
+        reg.register(
+            ValueKind::DateTime,
+            vec![
+                Literal::Str("2026-07-14T09:47:12Z".to_owned()),
+                Literal::Str("2000-01-01T00:00:00Z".to_owned()),
+            ],
+        );
+        reg.register(
+            ValueKind::Date,
+            vec![
+                Literal::Str("2026-07-14".to_owned()),
+                Literal::Str("2000-01-01".to_owned()),
+            ],
+        );
+        reg.register(
+            ValueKind::Time,
+            vec![
+                Literal::Str("09:47:12".to_owned()),
+                Literal::Str("00:00:00".to_owned()),
+            ],
+        );
+        reg.register(
+            ValueKind::Decimal,
+            vec![
+                Literal::Str("0".to_owned()),
+                Literal::Str("3.14".to_owned()),
+                Literal::Str("-100.00".to_owned()),
+            ],
+        );
+        reg.register(
+            ValueKind::Uuid,
+            vec![
+                Literal::Str("00000000-0000-0000-0000-000000000000".to_owned()),
+                Literal::Str("550e8400-e29b-41d4-a716-446655440000".to_owned()),
+            ],
+        );
 
         // `Any` is the union across every other registered kind.
         // Iterate `ValueKind::all()` (which excludes nothing but the

--- a/crates/panproto-lens/src/protolens.rs
+++ b/crates/panproto-lens/src/protolens.rs
@@ -1131,6 +1131,11 @@ pub mod elementary {
             panproto_gat::ValueKind::Bytes => "bytes",
             panproto_gat::ValueKind::Token => "token",
             panproto_gat::ValueKind::Null => "null",
+            panproto_gat::ValueKind::DateTime => "datetime",
+            panproto_gat::ValueKind::Date => "date",
+            panproto_gat::ValueKind::Time => "time",
+            panproto_gat::ValueKind::Decimal => "decimal",
+            panproto_gat::ValueKind::Uuid => "uuid",
             panproto_gat::ValueKind::Any => "any",
         }
     }

--- a/crates/panproto-mig/src/coerce/mod.rs
+++ b/crates/panproto-mig/src/coerce/mod.rs
@@ -274,6 +274,11 @@ pub const fn value_kind_label(kind: ValueKind) -> &'static str {
         ValueKind::Bytes => "bytes",
         ValueKind::Token => "token",
         ValueKind::Null => "null",
+        ValueKind::DateTime => "datetime",
+        ValueKind::Date => "date",
+        ValueKind::Time => "time",
+        ValueKind::Decimal => "decimal",
+        ValueKind::Uuid => "uuid",
         ValueKind::Any => "any",
     }
 }

--- a/crates/panproto-mig/src/coerce/witness.rs
+++ b/crates/panproto-mig/src/coerce/witness.rs
@@ -60,7 +60,12 @@ const fn value_kind_ordinal(kind: ValueKind) -> u8 {
         ValueKind::Str => 4,
         ValueKind::Bytes => 5,
         ValueKind::Token => 6,
-        ValueKind::Any => 7,
+        ValueKind::DateTime => 7,
+        ValueKind::Date => 8,
+        ValueKind::Time => 9,
+        ValueKind::Decimal => 10,
+        ValueKind::Uuid => 11,
+        ValueKind::Any => 12,
     }
 }
 

--- a/crates/panproto-theory-dsl/src/compile_theory.rs
+++ b/crates/panproto-theory-dsl/src/compile_theory.rs
@@ -640,6 +640,11 @@ fn parse_value_kind(s: &str) -> Result<ValueKind, TheoryDslError> {
         "bytes" => Ok(ValueKind::Bytes),
         "token" => Ok(ValueKind::Token),
         "null" => Ok(ValueKind::Null),
+        "date-time" | "datetime" => Ok(ValueKind::DateTime),
+        "date" => Ok(ValueKind::Date),
+        "time" => Ok(ValueKind::Time),
+        "decimal" => Ok(ValueKind::Decimal),
+        "uuid" => Ok(ValueKind::Uuid),
         "any" => Ok(ValueKind::Any),
         other => Err(TheoryDslError::UnknownValueKind {
             kind: other.to_owned(),


### PR DESCRIPTION
## Summary

Closes #190 (part 1). A record-to-theory encoder (didactic, lairs) could not recover a `datetime` / `date` / `time` / `Decimal` / `UUID` field: each collapsed to `ValueKind::Str`, so the distinction was lost on the forward path and unrecoverable coming back. This adds five refined scalar kinds to the GAT value-kind vocabulary.

## Changes

- `ValueKind` gains `DateTime`, `Date`, `Time`, `Decimal`, `Uuid`, each with a canonical `as_str` name (`date-time`/`date`/`time`/`decimal`/`uuid`).
- Wired through every exhaustive site: the reverse name→kind map (`panproto-theory-dsl`), the coercion ordinal / label / slug tables (`panproto-mig`, `panproto-lens`), the `all()` exhaustiveness guard, and the coercion-law sample registry (representative ISO-8601 / decimal / UUID samples).
- **Python SDK**: no change needed — `value_kind_for` is `ValueKind::as_str`-driven, so `"date-time"` maps to `ValueKind::DateTime` automatically.
- **Haskell / TypeScript bindings**: gain the variants for parity (`data ValueKind` + wire tag; the TS union).

## Scope note (#190 Q2–Q4)

Reference-vs-containment edges, per-field defaults/metadata, and containers/optionals are answered by existing layers, not the theory: `Edge.kind`, the schema constraint layer + protocol capability flags, and `Sort::dependent`/`SortParam` respectively. See the issue thread for the full write-up.

## Test plan

- New `sort.rs` test: each refined kind is distinct from `Str`, canonically named, and present in `all()`.
- `cargo nextest run -p panproto-gat -p panproto-theory-dsl -p panproto-lens -p panproto-py`: all pass (incl. `coercion_laws::registry_defaults_cover_every_primitive_kind`, which now covers the new kinds).
- `cargo clippy` (Rust 1.97) clean on the touched crates.

## Type of change

- [x] New feature (non-breaking)

## Affected surfaces

- [x] Rust crates — `panproto-gat`, `-mig`, `-lens`, `-theory-dsl`
- [x] Python SDK (`crates/panproto-py`) — automatic via `as_str`
- [x] TypeScript SDK — `ValueKind` union
- [x] Haskell bindings — `ValueKind`

## Linked issues

- Closes #190