### PR TITLE
fix(emit_pretty): cap ptrace-literal emissions per vertex walk

### DIFF
--- a/crates/panproto-parse/src/emit_pretty/cursor.rs
+++ b/crates/panproto-parse/src/emit_pretty/cursor.rs
@@ -137,6 +137,105 @@ thread_local! {
     /// recovers every matched edge across arbitrary nesting.
     pub(crate) static EMIT_FIELD_CONTEXT: std::cell::RefCell<Option<String>> =
         const { std::cell::RefCell::new(None) };
+    /// Per-vertex `ptrace`-literal budget: for each anonymous literal the
+    /// parser recorded on the current vertex (`ptrace-<slot> = T<lit>`), how
+    /// many emissions of that literal remain admissible on this vertex's
+    /// role-table (by-construction) walk. The parser records EVERY anonymous
+    /// token of a node as a `ptrace` slot, so the count is the literal's true
+    /// source multiplicity; a `field:<name>` recording of a field-bound token
+    /// is a redundant copy of the same `ptrace` slot. A single recorded
+    /// separator (bash `case_item`'s one `;;`) must therefore satisfy at most
+    /// one of the several separator CHOICEs its walk visits — the inner
+    /// `_terminator` inside `_statements`' `REPEAT(SEQ[_statement,
+    /// _terminator])`, `_statements`' trailing `CHOICE[_terminator|BLANK]`, and
+    /// the `case_item`'s own terminator FIELD — rather than being matched at
+    /// each. This mirrors the `sep_budget` cap the REPEAT walker applies to a
+    /// trailing mandatory separator, extended across the whole vertex walk to
+    /// the variant-tag literal tie-break in [`super::select_choice_with_trace`].
+    pub(crate) static EMIT_PTRACE_BUDGET: std::cell::RefCell<std::collections::HashMap<String, usize>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
+    /// The vertex whose `ptrace` budget is currently installed. A nested walk
+    /// of the SAME vertex (a hidden rule inlined onto the same vertex, e.g.
+    /// bash `_statements`) must keep the decrements accumulated across its
+    /// CHOICE sites, so re-entry for the same owner does not reinstall the
+    /// budget; a walk that descends into a CHILD vertex installs (and later
+    /// restores) that child's own budget.
+    pub(crate) static EMIT_PTRACE_BUDGET_OWNER: std::cell::RefCell<Option<panproto_gat::Name>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// RAII guard that restores the prior [`EMIT_PTRACE_BUDGET`] and
+/// [`EMIT_PTRACE_BUDGET_OWNER`] when the current vertex's walk unwinds.
+pub(crate) struct PtraceBudgetGuard {
+    prev_budget: std::collections::HashMap<String, usize>,
+    prev_owner: Option<panproto_gat::Name>,
+}
+
+impl Drop for PtraceBudgetGuard {
+    fn drop(&mut self) {
+        EMIT_PTRACE_BUDGET.with(|b| *b.borrow_mut() = std::mem::take(&mut self.prev_budget));
+        EMIT_PTRACE_BUDGET_OWNER.with(|o| *o.borrow_mut() = self.prev_owner.take());
+    }
+}
+
+/// Install `budget` as the active per-vertex `ptrace` budget owned by
+/// `owner`, returning a guard that restores the previous budget on drop.
+/// Returns `None` when `owner` already owns the active budget — a nested
+/// walk of the same vertex must accumulate decrements across its CHOICE
+/// sites rather than reset them.
+pub(crate) fn enter_ptrace_budget(
+    owner: &panproto_gat::Name,
+    budget: std::collections::HashMap<String, usize>,
+) -> Option<PtraceBudgetGuard> {
+    if is_ptrace_budget_owner(owner) {
+        return None;
+    }
+    let prev_budget = EMIT_PTRACE_BUDGET.with(|b| std::mem::replace(&mut *b.borrow_mut(), budget));
+    let prev_owner = EMIT_PTRACE_BUDGET_OWNER.with(|o| o.borrow_mut().replace(owner.clone()));
+    Some(PtraceBudgetGuard {
+        prev_budget,
+        prev_owner,
+    })
+}
+
+/// True iff `vertex_id` already owns the active `ptrace` budget.
+pub(crate) fn is_ptrace_budget_owner(vertex_id: &panproto_gat::Name) -> bool {
+    EMIT_PTRACE_BUDGET_OWNER
+        .with(|o| {
+            o.borrow()
+                .as_ref()
+                .map(|n| n.as_str() == vertex_id.as_str())
+        })
+        .unwrap_or(false)
+}
+
+/// True iff the active budget still admits an emission of `literal` (no
+/// recorded budget for it ⇒ unbounded, the canonical default for literals
+/// the parser never traced).
+pub(crate) fn ptrace_budget_allows(literal: &str) -> bool {
+    EMIT_PTRACE_BUDGET.with(|b| b.borrow().get(literal).is_none_or(|&rem| rem > 0))
+}
+
+/// Spend one unit of the active budget for `literal`, if any remains.
+/// A no-op when `literal` carries no recorded budget.
+pub(crate) fn ptrace_budget_consume(literal: &str) {
+    EMIT_PTRACE_BUDGET.with(|b| {
+        if let Some(rem) = b.borrow_mut().get_mut(literal) {
+            *rem = rem.saturating_sub(1);
+        }
+    });
+}
+
+/// Clone the active budget for an `OutputSnapshot`. Restored by
+/// [`restore_ptrace_budget`] so a REPEAT/OPTIONAL iteration that rolls back
+/// its emitted tokens also rolls back any budget it spent.
+pub(crate) fn snapshot_ptrace_budget() -> std::collections::HashMap<String, usize> {
+    EMIT_PTRACE_BUDGET.with(|b| b.borrow().clone())
+}
+
+/// Restore a budget captured by [`snapshot_ptrace_budget`].
+pub(crate) fn restore_ptrace_budget(snap: std::collections::HashMap<String, usize>) {
+    EMIT_PTRACE_BUDGET.with(|b| *b.borrow_mut() = snap);
 }
 
 /// RAII guard that restores the prior `EMIT_FIELD_CONTEXT` value on drop.

--- a/crates/panproto-parse/src/emit_pretty/layout.rs
+++ b/crates/panproto-parse/src/emit_pretty/layout.rs
@@ -135,6 +135,11 @@ pub(crate) struct Output<'a> {
 #[derive(Clone)]
 pub(crate) struct OutputSnapshot {
     pub(crate) tokens_len: usize,
+    /// The active per-vertex `ptrace` budget at snapshot time. Restored with
+    /// the token stream so a REPEAT/OPTIONAL iteration that rolls back also
+    /// rolls back any separator budget it spent (a `_terminator` that picked
+    /// `;;` inside a zero-progress iteration must un-spend it).
+    ptrace_budget: std::collections::HashMap<String, usize>,
 }
 
 impl<'a> Output<'a> {
@@ -333,11 +338,13 @@ impl<'a> Output<'a> {
     pub(crate) fn snapshot(&self) -> OutputSnapshot {
         OutputSnapshot {
             tokens_len: self.tokens.len(),
+            ptrace_budget: super::snapshot_ptrace_budget(),
         }
     }
 
     pub(crate) fn restore(&mut self, snap: OutputSnapshot) {
         self.tokens.truncate(snap.tokens_len);
+        super::restore_ptrace_budget(snap.ptrace_budget);
     }
 
     /// True iff at least one `Token::Lit` was pushed since `snap`.

--- a/crates/panproto-parse/src/emit_pretty/review.rs
+++ b/crates/panproto-parse/src/emit_pretty/review.rs
@@ -31,13 +31,14 @@ use super::{
     alt_satisfies_pre_alias_constraints, byte_span_consistent_with_parent, children_for,
     classify_seq_positions, clear_field_context, collect_field_names,
     collect_inner_field_names_expanded, contains_newline_pattern, current_field_context,
-    first_unconsumed_target_fingerprint, has_field_in, has_relevant_constraint, has_repeat_in,
-    is_blank_line_rule, is_connector_punctuation, is_immediate_token, is_newline_alt,
-    is_newline_like_pattern, is_no_space_external, is_whitespace_external,
-    is_whitespace_only_pattern, is_word_like, leaf_terminal_role, left_recursive_alts,
-    literal_strings, literal_value, mandatory_field_names, member_has_leading_bracket,
-    pattern_absorbs_leading_space, placeholder_for_pattern, pre_alias_symbol, prec_value,
-    push_field_context, reconstruct_subtree_bytes, reduces_to_immediate_token, referenced_symbols,
+    enter_ptrace_budget, first_unconsumed_target_fingerprint, has_field_in,
+    has_relevant_constraint, has_repeat_in, is_blank_line_rule, is_connector_punctuation,
+    is_immediate_token, is_newline_alt, is_newline_like_pattern, is_no_space_external,
+    is_ptrace_budget_owner, is_whitespace_external, is_whitespace_only_pattern, is_word_like,
+    leaf_terminal_role, left_recursive_alts, literal_strings, literal_value, mandatory_field_names,
+    member_has_leading_bracket, pattern_absorbs_leading_space, placeholder_for_pattern,
+    pre_alias_symbol, prec_value, ptrace_budget_allows, ptrace_budget_consume, push_field_context,
+    reconstruct_subtree_bytes, reduces_to_immediate_token, referenced_symbols,
     repeat_body_is_whole_vertex_item, repeat_has_bracket_keyed_member, seq_bracket_triggers_indent,
     seq_open_bracket_index, unbounded_negated_class, unwrap_prec, unwrap_to_string,
     vertex_has_byte_span, vertex_id_kind, yield_of_production,
@@ -735,6 +736,31 @@ pub(crate) fn walk_in_mu_frame(
     result
 }
 
+/// The per-vertex `ptrace`-literal budget for `vertex_id`: for each anonymous
+/// grammar token the parser recorded (`ptrace-<slot> = T<lit>`), the number of
+/// times that exact literal occurred in source. Because the parser records
+/// EVERY anonymous token of a node, this count is the literal's true source
+/// multiplicity — the byte-faithful cap on how many separator CHOICEs the
+/// vertex's by-construction walk may resolve to it (see [`EMIT_PTRACE_BUDGET`]).
+/// Empty when the vertex carries no `ptrace` fibre (canonical / transpiled
+/// schemas), leaving the literal tie-break unbounded as before.
+fn compute_ptrace_budget(
+    schema: &Schema,
+    vertex_id: &panproto_gat::Name,
+) -> std::collections::HashMap<String, usize> {
+    let mut budget = std::collections::HashMap::new();
+    if let Some(cs) = schema.constraints.get(vertex_id) {
+        for c in cs {
+            if c.sort.as_ref().starts_with("ptrace-") {
+                if let Some(lit) = c.value.strip_prefix('T') {
+                    *budget.entry(lit.to_owned()).or_insert(0) += 1;
+                }
+            }
+        }
+    }
+    budget
+}
+
 pub(crate) fn emit_production(
     protocol: &str,
     schema: &Schema,
@@ -744,6 +770,19 @@ pub(crate) fn emit_production(
     cursor: &mut ChildCursor<'_>,
     out: &mut Output<'_>,
 ) -> Result<(), ParseError> {
+    // Install this vertex's `ptrace` budget the first time the walk descends
+    // into it (owner changes). A nested walk of the SAME vertex — a hidden
+    // rule inlined onto it (bash `_statements`), or the successive SEQ members
+    // / REPEAT iterations of its own rule — keeps the budget already installed,
+    // so a separator literal spent at one CHOICE site stays spent at the next.
+    // Descending into a CHILD vertex installs (and, on unwind, restores) that
+    // child's own budget, so a `;;` inside a nested `case` cannot exhaust the
+    // outer case_item's budget.
+    let _budget_guard = if is_ptrace_budget_owner(vertex_id) {
+        None
+    } else {
+        enter_ptrace_budget(vertex_id, compute_ptrace_budget(schema, vertex_id))
+    };
     let depth = EMIT_DEPTH.with(|d| {
         let v = d.get() + 1;
         d.set(v);
@@ -1189,7 +1228,17 @@ pub(crate) fn emit_production_inner(
 ) -> Result<(), ParseError> {
     match production {
         Production::String { value } => {
-            out.token(value);
+            // Per-vertex `ptrace` budget: a literal recorded N times in source
+            // may be emitted at most N times across this vertex's walk. When a
+            // variant CHOICE has already spent the budget for this literal (the
+            // second/third `;;` a bash `case_item`'s separator CHOICEs would
+            // otherwise fabricate), suppress the duplicate. Literals with no
+            // recorded budget (canonical / by-construction schemas, and every
+            // token the parser never traced) are always admitted.
+            if ptrace_budget_allows(value) {
+                out.token(value);
+                ptrace_budget_consume(value);
+            }
             Ok(())
         }
         Production::Pattern { value } => {
@@ -1382,7 +1431,13 @@ pub(crate) fn emit_production_inner(
                         .find(|c| c.sort.as_ref() == sort)
                         .map(|c| c.value.clone())
                 }) {
-                    out.token(&v);
+                    // A `field:<name>` anonymous token is a redundant copy of a
+                    // `ptrace` slot, so it draws on the same per-vertex budget:
+                    // emit it only while that literal's source count is unspent.
+                    if ptrace_budget_allows(&v) {
+                        out.token(&v);
+                        ptrace_budget_consume(&v);
+                    }
                 }
                 // Otherwise surface nothing; the surrounding REPEAT /
                 // OPTIONAL / CHOICE backtracks when it sees no progress.
@@ -1668,6 +1723,14 @@ pub(crate) fn emit_production_inner(
                             }
                         });
                         out.token_with_role(value, Some(role));
+                        // Spend one unit of this literal's per-vertex budget: a
+                        // CHOICE just resolved to a recorded anonymous token, so
+                        // a later separator CHOICE on the same vertex may not
+                        // re-emit the same literal past its source count. A
+                        // snapshot/restore around a rolled-back REPEAT iteration
+                        // un-spends it. No-op for literals with no `ptrace`
+                        // budget.
+                        ptrace_budget_consume(value);
                         Ok(())
                     }
                     _ => {
@@ -2813,7 +2876,7 @@ pub(crate) fn pick_choice_with_cursor<'a>(
     for alt in alternatives {
         collect_field_names(alt, &mut alt_field_names);
     }
-    let trace_tokens: Vec<String> = schema
+    let mut trace_tokens: Vec<String> = schema
         .constraints
         .get(vertex_id)
         .map(|cs| {
@@ -2832,6 +2895,15 @@ pub(crate) fn pick_choice_with_cursor<'a>(
                 .collect()
         })
         .unwrap_or_default();
+    // Per-vertex `ptrace`-literal budget: drop any recorded literal whose
+    // emission budget is already spent, so the variant-tag tie-break below
+    // cannot re-satisfy the SAME separator at a later CHOICE site. bash
+    // `case_item` records one `;;` (as `ptrace` and, for a non-last item, a
+    // redundant `field:termination`), yet its walk visits three separator
+    // CHOICEs; once the first has claimed the `;;`, the rest fall through to
+    // their newline / BLANK alternative. Vertices with no `ptrace` fibre carry
+    // no budget, so this is a no-op on canonical / by-construction schemas.
+    trace_tokens.retain(|t| ptrace_budget_allows(t));
     // The recorded `field:<name>=<value>` pairs. An alternative that binds
     // field <name> to a literal set excluding <value> contradicts the parse
     // and is rejected before maximal-munch (JS `for (const x of …)`: the

--- a/crates/panproto-parse/tests/emit_pretty_rust_denovo.rs
+++ b/crates/panproto-parse/tests/emit_pretty_rust_denovo.rs
@@ -46,7 +46,7 @@ fn line_comment_does_not_absorb_following_item() {
         let src = b"// doc\npub mod schema;\n";
         let parsed = reg.parse_with_protocol("rust", src, "a.rs").expect("parse");
         let original = kind_multiset(&parsed);
-        let mut abs = parsed.clone();
+        let mut abs = parsed;
         abs.forget_layout_in_place();
         let bytes = reg
             .emit_pretty_with_protocol("rust", &abs)
@@ -82,7 +82,7 @@ fn opaque_token_tree_leaf_emits_verbatim() {
             .values()
             .find(|v| {
                 v.kind.as_ref() == "token_tree"
-                    && parsed.outgoing_edges(&v.id.to_string()).iter().any(|e| {
+                    && parsed.outgoing_edges(v.id.as_str()).iter().any(|e| {
                         parsed
                             .vertices
                             .get(&e.tgt)
@@ -94,9 +94,9 @@ fn opaque_token_tree_leaf_emits_verbatim() {
 
         // Collapse it to the opaque-leaf encoding: no children, one
         // literal-value carrying the whole run (including the `::`).
-        let mut s = parsed.clone();
+        let mut s = parsed;
         let child_ids: Vec<_> = s
-            .outgoing_edges(&tt_id.to_string())
+            .outgoing_edges(tt_id.as_str())
             .iter()
             .map(|e| e.tgt.clone())
             .collect();
@@ -169,7 +169,7 @@ fn forget_layout_strips_blank_lines_before() {
             recorded > 0,
             "expected the walker to record blank-lines-before on the spaced items"
         );
-        let mut abs = parsed.clone();
+        let mut abs = parsed;
         abs.forget_layout_in_place();
         let remaining = abs
             .constraints

--- a/crates/panproto-parse/tests/emit_relocated_subtree.rs
+++ b/crates/panproto-parse/tests/emit_relocated_subtree.rs
@@ -56,10 +56,15 @@ fn relocated_subtree_separates_from_sibling() {
         let root = parsed
             .vertices
             .keys()
-            .find(|id| parsed.incoming.get(*id).is_none_or(|e| e.is_empty()))
+            .find(|id| {
+                parsed
+                    .incoming
+                    .get(*id)
+                    .is_none_or(smallvec::SmallVec::is_empty)
+            })
             .expect("a structural root")
             .clone();
-        let mut relocated = parsed.clone();
+        let mut relocated = parsed;
         let cs = relocated
             .constraints
             .get_mut(&root)


### PR DESCRIPTION
## Summary

Closes #204. On the by-construction emit path (byte-position fibre stripped, so `emit_pretty` uses the role-table walk), a bash `case`/`esac` over-emitted the `;;` terminator (three per case item) and dropped the newlines between items, so the round-trip oracle's re-parse gained an `ERROR` node.

## Root cause

A `case_item` records its single `;;` once in the ordered `ptrace` fibre (`capture_production_trace` traces every anonymous token). But the `case_item` walk visits **three** separator CHOICEs — `_statements`' inner `_terminator`, its trailing `CHOICE[_terminator|BLANK]`, and the `case_item`'s own terminator field — and each independently matched the single `;;` against the *unordered* trace-token multiset, because the statement-terminating newline that should fill the inner slots rode the stripped interstitial fibre (its `\r?\n` pattern scores zero literal overlap).

## Fix

A **per-vertex `ptrace`-literal budget**: the `ptrace` count is a literal's true source multiplicity, so a literal recorded N times may satisfy at most N separator CHOICEs across one vertex's emit walk. Mirrors the existing `sep_budget`, extended across the whole walk.

- `cursor.rs`: thread-local budget + RAII owner scope + allow/consume/snapshot/restore (mirrors `EMIT_FIELD_CONTEXT`).
- `review.rs`: `compute_ptrace_budget`; installed per vertex on owner change (nested `case` gets its own, restored on unwind); filters spent literals from the variant-tag tie-break; the three literal-emission arms consume a unit and suppress once spent.
- `layout.rs`: `OutputSnapshot` captures/restores the budget so a rolled-back REPEAT iteration un-spends it.

Capping at the recorded source count is byte-faithful, so verbatim-replay is untouched; a vertex with no `ptrace` fibre (canonical/transpiled schemas) carries an empty budget and is unchanged.

## Validation

- `cargo nextest run -p panproto-parse --features grammars,lang-bash -E 'binary(emit_pretty_core_pack)'` → 5/5 (incl. `bash::case_esac`: one `;;` per item, no ERROR on re-parse).
- Full corpus gate `cargo nextest run -p panproto-parse --all-features` → **342 passed, 0 skipped** (incl. the heavy byte-faithful `corpus_verified_protocols_round_trip_full_corpus`). No regressions.
- `cargo fmt --all --check` clean; `cargo clippy -p panproto-parse --all-targets --all-features -- -D warnings` clean (stable 1.97; also fixes two pre-existing lints in feature-gated emit tests).

## Type of change

- [x] Bug fix (non-breaking)

## Affected surfaces

- [x] Rust crates — `panproto-parse`

## Linked issues

- Closes #204