### PR TITLE
fix(ci): include dev-dependencies in the crates.io publish order

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -125,9 +125,12 @@ jobs:
           # `cargo metadata` so this list can never drift from the workspace:
           # adding or removing a crate needs no edit here (a stale entry for a
           # removed crate would fail with "did not match any packages"; a
-          # missing entry for a new crate would fail its dependents). Only
-          # normal and build dependencies gate ordering; dev-dependencies do
-          # not, and `publish = false` crates are excluded.
+          # missing entry for a new crate would fail its dependents). Normal,
+          # build, AND dev dependencies gate ordering: `cargo publish` must
+          # resolve a crate's dev-dependencies too, so a workspace crate used
+          # as a dev-dependency must be published before its dependent (e.g.
+          # panproto-check dev-depends on panproto-protocols). `publish = false`
+          # crates are excluded.
           CRATES=()
           while IFS= read -r crate_name; do
             [ -n "$crate_name" ] && CRATES+=("$crate_name")
@@ -146,7 +149,7 @@ jobs:
           for n, p in pub.items():
               deps = []
               for d in p["dependencies"]:
-                  if d["name"] in names and d.get("kind") in (None, "build"):
+                  if d["name"] in names and d.get("kind") in (None, "build", "dev"):
                       deps.append(d["name"])
               edges[n] = sorted(set(deps))
           order, seen, stack = [], set(), set()


### PR DESCRIPTION
## Summary

The crates.io publish for v0.58.0 failed: `panproto-check` was ordered *before* `panproto-protocols`, and its publish failed to select `panproto-protocols 0.58.0`. `panproto-check` **dev-depends** on `panproto-protocols`, and `cargo publish` resolves a crate's dev-dependencies too, so a workspace crate used as a dev-dependency must be published before its dependent.

The `cargo metadata`-derived publish order (added in #218) excluded dev-dependencies from the topological ordering — the comment even asserted "dev-dependencies do not gate publishing." That was wrong.

## Changes

- Include `kind == "dev"` alongside normal and build dependencies when building the topological-order edges.

## Validation

Verified against the actual publish requirement (not the previous circular self-check): with dev-deps included, the workspace has **no dependency cycles**, **zero ordering violations** (every dependency — including dev — precedes its dependent), and `panproto-protocols` now correctly precedes `panproto-check`. Embedded Python compiles; `bash -n` clean.

## Type of change

- [x] Build / CI / release infrastructure

## Affected surfaces

- [x] CI workflows (`.github/workflows/`)