### PR TITLE
fix(inst): transparent ref/record-schema indirections (#237); add symmetricLens; doc-count fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to panproto will be documented in this file.
 
+## [0.62.0] - 2026-07-22
+
+### Added
+
+- **`Panproto.symmetricLens(left, right)`** (`@panproto/core`): a public, high-level constructor for a `SymmetricLensHandle`, matching the existing `lens` and `protolensChain` accessors. A symmetric lens previously had to be built through the lower-level `SymmetricLensHandle.fromSchemas` static, which required passing the internal WASM module handle. Now `p.symmetricLens(a, b)` returns a handle whose `syncLeftToRight` and `syncRightToLeft` methods propagate a change on either side to the other, preserving each side's private information in the shared complement.
+
+### Fixed
+
+- **`ref` and `record-schema` edges are transparent to the instance parser** (`panproto-inst`): a field whose type is a named definition (a nameless `ref` edge) or a record body (a nameless `record-schema` edge) was skipped by `parse_object`, so the referenced object's fields fell through into `extra_fields` as an opaque `Unknown` and the record parsed to a shallow one-node instance. A structurally-equivalent schema that inlines the same nesting with named `prop` edges parsed deep, so the same data produced two different instance graphs depending on the protocol, which breaks the "every protocol is a view over one graph" premise and makes lenses, field transforms, and queries protocol-dependent. `parse_object` now resolves through a nameless `ref` or `record-schema` indirection to the object definition it denotes, anchoring the node there so its fields materialize on the instance graph exactly as an inlined definition would; a *named* `ref` (the labelled reference some protocols emit for a pointer to a named definition) stays an ordinary field. The change is parse-only: serialization already reconstructed the nested JSON, so the round-trip is unchanged. Closes #237.
+- Corrected stale built-in-protocol counts in the TypeScript SDK doc comments (`@panproto/core`): the protocol-name accessors (`protocol`, `listProtocols`, `getProtocolNames`) now read 54, not a stale 76; the I/O codec-registry comments drop the stale 77 rather than assert a build-feature-dependent count.
+
 ## [0.61.0] - 2026-07-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "miette",
@@ -1924,7 +1924,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "ciborium",
  "git2",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "divan",
  "insta",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-dsl-eval"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "nickel-lang",
  "serde",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "divan",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "chumsky",
  "divan",
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "divan",
  "miette",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "divan",
  "git2",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "git2",
  "miette",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "cc",
  "divan",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2206,7 +2206,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2247,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "divan",
  "insta",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "divan",
  "miette",
@@ -2311,7 +2311,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2328,7 +2328,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "divan",
  "memchr",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "divan",
  "miette",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.61.0"
+version = "0.62.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -107,27 +107,27 @@ tree-sitter = "0.26"
 tree-sitter-tags = "0.26"
 
 # Workspace crates
-panproto-gat = { version = "0.61.0", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.61.0", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.61.0", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.61.0", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.61.0", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.61.0", path = "crates/panproto-lens" }
-panproto-dsl-eval = { version = "0.61.0", path = "crates/panproto-dsl-eval" }
-panproto-lens-dsl = { version = "0.61.0", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.61.0", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.61.0", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.61.0", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.61.0", path = "crates/panproto-core" }
-panproto-io = { version = "0.61.0", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.61.0", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.61.0", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.61.0", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.61.0", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.61.0", path = "crates/panproto-parse" }
-panproto-project = { version = "0.61.0", path = "crates/panproto-project" }
-panproto-git = { version = "0.61.0", path = "crates/panproto-git" }
-panproto-xrpc = { version = "0.61.0", path = "crates/panproto-xrpc" }
+panproto-gat = { version = "0.62.0", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.62.0", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.62.0", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.62.0", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.62.0", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.62.0", path = "crates/panproto-lens" }
+panproto-dsl-eval = { version = "0.62.0", path = "crates/panproto-dsl-eval" }
+panproto-lens-dsl = { version = "0.62.0", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.62.0", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.62.0", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.62.0", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.62.0", path = "crates/panproto-core" }
+panproto-io = { version = "0.62.0", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.62.0", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.62.0", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.62.0", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.62.0", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.62.0", path = "crates/panproto-parse" }
+panproto-project = { version = "0.62.0", path = "crates/panproto-project" }
+panproto-git = { version = "0.62.0", path = "crates/panproto-git" }
+panproto-xrpc = { version = "0.62.0", path = "crates/panproto-xrpc" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:             0.61.0
+version:             0.62.0
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/python-grammars-all/pyproject.toml
+++ b/bindings/python-grammars-all/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.61,<0.62",
+    "panproto>=0.62,<0.63",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-data/pyproject.toml
+++ b/bindings/python-grammars-data/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.61,<0.62",
+    "panproto>=0.62,<0.63",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-devops/pyproject.toml
+++ b/bindings/python-grammars-devops/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.61,<0.62",
+    "panproto>=0.62,<0.63",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-functional/pyproject.toml
+++ b/bindings/python-grammars-functional/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # companion via the entry point declared below; without panproto
     # installed there is no consumer for the grammars this package
     # ships.
-    "panproto>=0.61,<0.62",
+    "panproto>=0.62,<0.63",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-jvm/pyproject.toml
+++ b/bindings/python-grammars-jvm/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.61,<0.62",
+    "panproto>=0.62,<0.63",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-mobile/pyproject.toml
+++ b/bindings/python-grammars-mobile/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.61,<0.62",
+    "panproto>=0.62,<0.63",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-music/pyproject.toml
+++ b/bindings/python-grammars-music/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.61,<0.62",
+    "panproto>=0.62,<0.63",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-scripting/pyproject.toml
+++ b/bindings/python-grammars-scripting/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.61,<0.62",
+    "panproto>=0.62,<0.63",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-systems/pyproject.toml
+++ b/bindings/python-grammars-systems/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.61,<0.62",
+    "panproto>=0.62,<0.63",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-web/pyproject.toml
+++ b/bindings/python-grammars-web/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.61,<0.62",
+    "panproto>=0.62,<0.63",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/bindings/typescript/src/io.ts
+++ b/bindings/typescript/src/io.ts
@@ -2,7 +2,7 @@
  * I/O protocol registry for parsing and emitting instances.
  *
  * Wraps the WASM-side IoRegistry and provides parse/emit operations
- * across 77 protocol codecs organized by category.
+ * across the built-in protocol codecs organized by category.
  *
  * @module
  */

--- a/bindings/typescript/src/panproto.ts
+++ b/bindings/typescript/src/panproto.ts
@@ -10,7 +10,7 @@
 import type { WasmModule, ProtocolSpec, DiffReport, FullSchemaDiff, SchemaValidationIssue } from './types.js';
 import { PanprotoError, WasmError } from './types.js';
 import { loadWasm, type WasmGlueModule, createHandle } from './wasm.js';
-import { LensHandle, ProtolensChainHandle } from './lens.js';
+import { LensHandle, ProtolensChainHandle, SymmetricLensHandle } from './lens.js';
 import { packToWasm, unpackFromWasm } from './msgpack.js';
 import {
   Protocol,
@@ -110,7 +110,7 @@ export class Panproto implements Disposable {
       return proto;
     }
 
-    // Try fetching from WASM (supports all 76 protocols)
+    // Try fetching from WASM (supports all 54 protocols)
     const wasmSpec = getBuiltinProtocol(name, this.#wasm);
     if (wasmSpec) {
       const proto = defineProtocol(wasmSpec, this.#wasm);
@@ -518,7 +518,7 @@ export class Panproto implements Disposable {
   /**
    * Create an I/O protocol registry for parsing and emitting instances.
    *
-   * The returned registry wraps all 77 built-in protocol codecs and
+   * The returned registry wraps all built-in protocol codecs and
    * implements `Disposable` for automatic cleanup.
    *
    * @returns A new IoRegistry
@@ -564,7 +564,7 @@ export class Panproto implements Disposable {
   /**
    * List all built-in protocol names.
    *
-   * Returns the names of all 76 built-in protocols supported by the
+   * Returns the names of all 54 built-in protocols supported by the
    * WASM layer.
    *
    * @returns Array of protocol name strings
@@ -634,6 +634,25 @@ export class Panproto implements Disposable {
    */
   protolensChain(from: BuiltSchema, to: BuiltSchema): ProtolensChainHandle {
     return ProtolensChainHandle.autoGenerate(from, to, this.#wasm);
+  }
+
+  /**
+   * Create a symmetric lens between two schemas for bidirectional sync.
+   *
+   * Unlike an asymmetric lens (which has a distinguished source and
+   * view), a symmetric lens treats both schemas as peers: a change on
+   * either side propagates to the other through
+   * {@link SymmetricLensHandle.syncLeftToRight} /
+   * {@link SymmetricLensHandle.syncRightToLeft}, with each side's
+   * private information preserved in the shared complement.
+   *
+   * @param left - The left schema
+   * @param right - The right schema
+   * @returns A disposable SymmetricLensHandle for bidirectional sync
+   * @throws {@link WasmError} if symmetric-lens construction fails
+   */
+  symmetricLens(left: BuiltSchema, right: BuiltSchema): SymmetricLensHandle {
+    return SymmetricLensHandle.fromSchemas(left, right, this.#wasm);
   }
 
   /**

--- a/bindings/typescript/src/protocol.ts
+++ b/bindings/typescript/src/protocol.ts
@@ -230,7 +230,7 @@ export const BUILTIN_PROTOCOLS: ReadonlyMap<string, ProtocolSpec> = new Map([
   ['json-schema', JSON_SCHEMA_SPEC],
 ]);
 
-/** Lazily cached list of all 76 built-in protocol names from WASM. */
+/** Lazily cached list of all 54 built-in protocol names from WASM. */
 let _protocolNamesCache: readonly string[] | null = null;
 
 /**
@@ -239,7 +239,7 @@ let _protocolNamesCache: readonly string[] | null = null;
  * Lazily fetches the full list from WASM on first call and caches it.
  *
  * @param wasm - The WASM module
- * @returns Array of all 76 built-in protocol names
+ * @returns Array of all 54 built-in protocol names
  */
 export function getProtocolNames(wasm: WasmModule): readonly string[] {
   if (_protocolNamesCache !== null) return _protocolNamesCache;
@@ -252,7 +252,7 @@ export function getProtocolNames(wasm: WasmModule): readonly string[] {
  * Get a built-in protocol spec by name from WASM.
  *
  * This fetches the full protocol definition from the WASM layer,
- * which includes all 76 protocols (not just the 5 hardcoded ones).
+ * which includes all 54 protocols (not just the 5 hardcoded ones).
  *
  * @param name - The protocol name
  * @param wasm - The WASM module

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.61.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.61.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.61.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.61.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.61.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.61.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.61.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.61.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.61.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.61.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-inst/src/parse.rs
+++ b/crates/panproto-inst/src/parse.rs
@@ -102,6 +102,48 @@ fn walk_json(
     Ok(())
 }
 
+/// A nameless `ref` or `record-schema` edge is a *transparent type
+/// indirection*: it names the type of a vertex (a record's body, or a
+/// field whose type is a named definition) rather than a child field or
+/// an ordered-list slot. The instance graph must see through it, so the
+/// referenced definition's fields materialize on the referring node
+/// exactly as an inlined definition would. Otherwise the same record
+/// parses to a *shallow* instance under a protocol that models nesting
+/// with these indirections and a *deep* instance under one that inlines
+/// it with `prop` edges: the same data, two different graphs, which
+/// breaks the "every protocol is a view over one graph" premise and
+/// makes lenses and field transforms protocol-dependent.
+///
+/// `ref` and `record-schema` are structural edge-kind vocabulary shared
+/// across protocols, not protocol names. Only a *nameless* such edge is
+/// an indirection: a *named* `ref` (the labelled reference some
+/// protocols emit for a pointer to a named definition) is an ordinary
+/// field, matched by its label like any other.
+fn is_transparent_indirection(kind: &str) -> bool {
+    matches!(kind, "ref" | "record-schema")
+}
+
+/// Follow transparent type-indirection edges from `vertex_id` to the
+/// object/record vertex they ultimately denote, so that parsing and
+/// serialization anchor the node at the resolved definition (whose
+/// outgoing edges are the real fields) rather than at the indirection
+/// vertex (whose sole anonymous edge would otherwise be mistaken for a
+/// list slot). Only a vertex whose *sole* outgoing edge is a nameless
+/// indirection is followed; a `seen` set bounds the walk against cycles.
+fn resolve_transparent_indirection<'a>(schema: &'a Schema, vertex_id: &'a str) -> &'a str {
+    let mut current = vertex_id;
+    let mut seen = std::collections::HashSet::new();
+    while seen.insert(current) {
+        match schema.outgoing_edges(current) {
+            [edge] if edge.name.is_none() && is_transparent_indirection(&edge.kind) => {
+                current = &edge.tgt;
+            }
+            _ => break,
+        }
+    }
+    current
+}
+
 /// Parse a JSON object into a node with children.
 fn parse_object(
     schema: &Schema,
@@ -111,15 +153,20 @@ fn parse_object(
     state: &mut ParseState,
     path: &str,
 ) -> Result<(), ParseError> {
-    let mut node = Node::new(node_id, vertex_id);
+    // Resolve transparent type indirections (`ref` / `record-schema`)
+    // so the node anchors at the object definition they denote and its
+    // fields materialize here rather than falling through to
+    // `extra_fields`.
+    let anchor = resolve_transparent_indirection(schema, vertex_id);
+    let mut node = Node::new(node_id, anchor);
 
     // Check for discriminator ($type field)
     if let Some(serde_json::Value::String(disc)) = map.get("$type") {
         node.discriminator = Some(panproto_gat::Name::from(disc.as_str()));
     }
 
-    // Get outgoing edges from schema for this vertex
-    let outgoing: Vec<Edge> = schema.outgoing_edges(vertex_id).to_vec();
+    // Get outgoing edges from schema for the resolved (anchor) vertex
+    let outgoing: Vec<Edge> = schema.outgoing_edges(anchor).to_vec();
 
     // Track which fields we've handled
     let mut handled_fields = std::collections::HashSet::new();

--- a/tests/integration/tests/issue_237_ref_transparency.rs
+++ b/tests/integration/tests/issue_237_ref_transparency.rs
@@ -9,6 +9,8 @@
 //! opaque `Unknown`), while the inlined protocol parsed deep — the same
 //! data, two different graphs.
 
+use std::error::Error;
+
 use panproto_inst::{parse_json, to_json};
 use panproto_protocols::atproto;
 
@@ -39,10 +41,15 @@ fn json_schema_doc() -> serde_json::Value {
 
 /// A structural signature of an instance graph that ignores vertex ids
 /// (which differ by protocol) but captures shape: node/arc counts, the
-/// `(kind, name)` of every arc, every leaf value, and any `extra_fields`
-/// keys (a nonempty set is exactly the shallow-parse symptom).
-fn signature(schema: &panproto_schema::Schema, root: &str, record: &serde_json::Value) -> String {
-    let inst = parse_json(schema, root, record).expect("parse_json");
+/// `(kind, name)` of every arc, every leaf value, and the total
+/// `extra_fields` count (a nonzero count is exactly the shallow-parse
+/// symptom).
+fn signature(
+    schema: &panproto_schema::Schema,
+    root: &str,
+    record: &serde_json::Value,
+) -> Result<String, Box<dyn Error>> {
+    let inst = parse_json(schema, root, record)?;
     let mut arcs: Vec<String> = inst
         .arcs
         .iter()
@@ -56,25 +63,24 @@ fn signature(schema: &panproto_schema::Schema, root: &str, record: &serde_json::
         .collect();
     leaves.sort();
     let extra: usize = inst.nodes.values().map(|n| n.extra_fields.len()).sum();
-    format!(
+    Ok(format!(
         "nodes={} arcs={:?} leaves={:?} extra_fields={}",
         inst.nodes.len(),
         arcs,
         leaves,
         extra
-    )
+    ))
 }
 
 #[test]
-fn ref_and_inlined_schemas_produce_the_same_instance_graph() {
-    let at = atproto::parse_lexicon(&atproto_lexicon()).expect("atproto schema");
-    let js = panproto_protocols::parse_schema_document("json-schema", &json_schema_doc())
-        .expect("json-schema schema");
+fn ref_and_inlined_schemas_produce_the_same_instance_graph() -> Result<(), Box<dyn Error>> {
+    let at = atproto::parse_lexicon(&atproto_lexicon())?;
+    let js = panproto_protocols::parse_schema_document("json-schema", &json_schema_doc())?;
 
     let record = serde_json::json!({ "kf": { "t": 5 } });
 
-    let at_sig = signature(&at, "d.a", &record);
-    let js_sig = signature(&js, "root", &record);
+    let at_sig = signature(&at, "d.a", &record)?;
+    let js_sig = signature(&js, "root", &record)?;
 
     assert_eq!(
         at_sig, js_sig,
@@ -82,7 +88,7 @@ fn ref_and_inlined_schemas_produce_the_same_instance_graph() {
     );
 
     // The shallow-parse symptom: the referenced object must NOT collapse
-    // into extra_fields. Signature already checks extra_fields=0, but
+    // into extra_fields. The signature already encodes extra_fields=0, but
     // assert the deep shape explicitly.
     assert!(
         at_sig.contains("nodes=3"),
@@ -92,16 +98,18 @@ fn ref_and_inlined_schemas_produce_the_same_instance_graph() {
         at_sig.contains("extra_fields=0"),
         "referenced object must not land in extra_fields, got: {at_sig}"
     );
+    Ok(())
 }
 
 #[test]
-fn transparent_indirection_preserves_round_trip() {
-    let at = atproto::parse_lexicon(&atproto_lexicon()).expect("atproto schema");
+fn transparent_indirection_preserves_round_trip() -> Result<(), Box<dyn Error>> {
+    let at = atproto::parse_lexicon(&atproto_lexicon())?;
     let record = serde_json::json!({ "kf": { "t": 5 } });
-    let inst = parse_json(&at, "d.a", &record).expect("parse_json");
+    let inst = parse_json(&at, "d.a", &record)?;
     assert_eq!(
         to_json(&at, &inst),
         record,
         "deep parse must still serialize back to the original record"
     );
+    Ok(())
 }

--- a/tests/integration/tests/issue_237_ref_transparency.rs
+++ b/tests/integration/tests/issue_237_ref_transparency.rs
@@ -1,0 +1,107 @@
+//! Regression test for issue #237.
+//!
+//! A `ref` / `record-schema` edge is a transparent type indirection, so
+//! a record whose field type is a named definition must parse to the
+//! *same* instance graph as the structurally-equivalent schema that
+//! inlines the definition with `prop` edges. Before the fix, a protocol
+//! that models nesting with `ref` edges parsed to a shallow one-node
+//! instance (the referenced object landing in `extra_fields` as an
+//! opaque `Unknown`), while the inlined protocol parsed deep — the same
+//! data, two different graphs.
+
+use panproto_inst::{parse_json, to_json};
+use panproto_protocols::atproto;
+
+/// A lexicon whose record body has one field `kf` of type `ref` to a
+/// sibling def `#k` (an object with an integer field `t`).
+fn atproto_lexicon() -> serde_json::Value {
+    serde_json::json!({
+        "lexicon": 1, "id": "d.a", "defs": {
+            "main": { "type": "record", "key": "tid", "record": {
+                "type": "object", "required": ["kf"],
+                "properties": { "kf": { "type": "ref", "ref": "#k" } } } },
+            "k": { "type": "object", "required": ["t"],
+                "properties": { "t": { "type": "integer" } } }
+        }
+    })
+}
+
+/// The same logical shape, inlined (no indirection): an object with a
+/// nested object field.
+fn json_schema_doc() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object", "required": ["kf"],
+        "properties": { "kf": {
+            "type": "object", "required": ["t"],
+            "properties": { "t": { "type": "integer" } } } }
+    })
+}
+
+/// A structural signature of an instance graph that ignores vertex ids
+/// (which differ by protocol) but captures shape: node/arc counts, the
+/// `(kind, name)` of every arc, every leaf value, and any `extra_fields`
+/// keys (a nonempty set is exactly the shallow-parse symptom).
+fn signature(schema: &panproto_schema::Schema, root: &str, record: &serde_json::Value) -> String {
+    let inst = parse_json(schema, root, record).expect("parse_json");
+    let mut arcs: Vec<String> = inst
+        .arcs
+        .iter()
+        .map(|(_, _, e)| format!("{}[{}]", e.kind, e.name.as_deref().unwrap_or("")))
+        .collect();
+    arcs.sort();
+    let mut leaves: Vec<String> = inst
+        .nodes
+        .values()
+        .filter_map(|n| n.value.as_ref().map(|v| format!("{v:?}")))
+        .collect();
+    leaves.sort();
+    let extra: usize = inst.nodes.values().map(|n| n.extra_fields.len()).sum();
+    format!(
+        "nodes={} arcs={:?} leaves={:?} extra_fields={}",
+        inst.nodes.len(),
+        arcs,
+        leaves,
+        extra
+    )
+}
+
+#[test]
+fn ref_and_inlined_schemas_produce_the_same_instance_graph() {
+    let at = atproto::parse_lexicon(&atproto_lexicon()).expect("atproto schema");
+    let js = panproto_protocols::parse_schema_document("json-schema", &json_schema_doc())
+        .expect("json-schema schema");
+
+    let record = serde_json::json!({ "kf": { "t": 5 } });
+
+    let at_sig = signature(&at, "d.a", &record);
+    let js_sig = signature(&js, "root", &record);
+
+    assert_eq!(
+        at_sig, js_sig,
+        "ref-based and inlined schemas must materialize the same instance graph"
+    );
+
+    // The shallow-parse symptom: the referenced object must NOT collapse
+    // into extra_fields. Signature already checks extra_fields=0, but
+    // assert the deep shape explicitly.
+    assert!(
+        at_sig.contains("nodes=3"),
+        "expected a deep 3-node graph, got: {at_sig}"
+    );
+    assert!(
+        at_sig.contains("extra_fields=0"),
+        "referenced object must not land in extra_fields, got: {at_sig}"
+    );
+}
+
+#[test]
+fn transparent_indirection_preserves_round_trip() {
+    let at = atproto::parse_lexicon(&atproto_lexicon()).expect("atproto schema");
+    let record = serde_json::json!({ "kf": { "t": 5 } });
+    let inst = parse_json(&at, "d.a", &record).expect("parse_json");
+    assert_eq!(
+        to_json(&at, &inst),
+        record,
+        "deep parse must still serialize back to the original record"
+    );
+}


### PR DESCRIPTION
Fixes #237, and folds in two riders it surfaced (a public symmetric-lens constructor and a doc-comment count correction).

## `ref` / `record-schema` transparency (#237)

A field whose type is a named definition (a nameless `ref` edge) or a record body (a nameless `record-schema` edge) was skipped by `parse_object`: the referenced object's fields fell through into `extra_fields` as an opaque `Unknown`, so the record parsed to a **shallow** one-node instance. A structurally-equivalent schema that inlines the same nesting with named `prop` edges parsed **deep**, so the same data produced two different instance graphs depending on the protocol, making lenses, field transforms, and queries protocol-dependent.

`parse_object` now resolves through a nameless `ref`/`record-schema` indirection to the object definition it denotes, anchoring the node there so its fields materialize on the instance graph exactly as an inlined definition would. Re-anchoring at the resolved object also keeps serialization correct: the object def's named edges stop the all-anonymous-edges "list vertex" heuristic from misfiring, so no serialize-side change is needed. A *named* `ref` (a `$ref`-style labelled pointer, as some protocols emit) stays an ordinary field, matched by its label. The change is parse-only; `to_json` already reconstructed the nested JSON, so the round-trip is unchanged.

The two affected edge kinds are structural vocabulary, not protocol names, and are the only nameless indirections in the built-in set (a survey confirmed `record-schema` is unique to one protocol and every other protocol's `ref` edges are named), so the blast radius is exactly the records that previously parsed shallow.

**Verified:** a record with a `ref`-typed field now parses to the same instance graph (node/arc structure, edge kinds, leaf values, empty `extra_fields`) as the inlined equivalent, and still round-trips. New regression test `tests/integration/tests/issue_237_ref_transparency.rs`.

## `Panproto.symmetricLens(left, right)`

A public, high-level constructor for a `SymmetricLensHandle`, alongside the existing `lens` / `protolensChain` accessors. Previously a symmetric lens could only be built via the lower-level `SymmetricLensHandle.fromSchemas` static, which requires passing the internal WASM module handle. Now `p.symmetricLens(a, b).syncLeftToRight(...)` / `.syncRightToLeft(...)` works from the high-level object.

## Stale doc-comment counts

The TypeScript SDK doc comments claimed "76 protocols" / "77 codecs"; the real `builtin_protocol_names()` count is 54. The protocol-name accessors (`protocol`, `listProtocols`, `getProtocolNames`) now read 54; the I/O codec-registry comments drop the build-feature-dependent count rather than hardcode a stale one.

## Testing

- `cargo nextest run --workspace`: green.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo doc` (changed crate): clean.
- `tsc --noEmit` (TypeScript SDK): clean.
- Version bumped to **0.62.0** (new public API + behavior fix); `check_version_consistency.py` passes.
