### PR TITLE
feat(vcs): skip_verify escape hatch for Repository::add (#239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to panproto will be documented in this file.
 
+## [0.63.0] - 2026-07-23
+
+### Added
+
+- **`Repository::add_with_options` and a `skip_verify` escape hatch for staging** (`panproto-vcs`, `panproto`, `schema` CLI): `add` previously always ran GAT migration validation (a bounded model check) against HEAD on every staged schema, with no opt-out, so building a VCS of many historical versions in sequence was impractical (each ~800-vertex `add` past the first cost minutes of validation). `add` now delegates to `add_with_options(schema, &AddOptions { skip_verify })`, mirroring `commit`'s existing `skip_verify`: with the flag set, the migration is still derived and recorded but validation is skipped and the stage is left `Pending`, which a default `commit` treats as non-blocking. It is surfaced as `repo.add(schema, skip_verify=True)` in Python and `schema add --skip-verify` in the CLI, so a caller replaying already-validated released versions can build a historical VCS without paying the per-`add` model check. Closes #239.
+
 ## [0.62.0] - 2026-07-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "anyhow",
  "miette",
@@ -1924,7 +1924,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "ciborium",
  "git2",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "divan",
  "insta",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-dsl-eval"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "nickel-lang",
  "serde",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "divan",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "chumsky",
  "divan",
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "divan",
  "miette",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "divan",
  "git2",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "git2",
  "miette",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "cc",
  "divan",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2206,7 +2206,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2247,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "divan",
  "insta",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "divan",
  "miette",
@@ -2311,7 +2311,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2328,7 +2328,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "divan",
  "memchr",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "divan",
  "miette",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.62.0"
+version = "0.63.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -107,27 +107,27 @@ tree-sitter = "0.26"
 tree-sitter-tags = "0.26"
 
 # Workspace crates
-panproto-gat = { version = "0.62.0", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.62.0", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.62.0", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.62.0", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.62.0", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.62.0", path = "crates/panproto-lens" }
-panproto-dsl-eval = { version = "0.62.0", path = "crates/panproto-dsl-eval" }
-panproto-lens-dsl = { version = "0.62.0", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.62.0", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.62.0", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.62.0", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.62.0", path = "crates/panproto-core" }
-panproto-io = { version = "0.62.0", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.62.0", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.62.0", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.62.0", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.62.0", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.62.0", path = "crates/panproto-parse" }
-panproto-project = { version = "0.62.0", path = "crates/panproto-project" }
-panproto-git = { version = "0.62.0", path = "crates/panproto-git" }
-panproto-xrpc = { version = "0.62.0", path = "crates/panproto-xrpc" }
+panproto-gat = { version = "0.63.0", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.63.0", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.63.0", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.63.0", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.63.0", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.63.0", path = "crates/panproto-lens" }
+panproto-dsl-eval = { version = "0.63.0", path = "crates/panproto-dsl-eval" }
+panproto-lens-dsl = { version = "0.63.0", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.63.0", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.63.0", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.63.0", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.63.0", path = "crates/panproto-core" }
+panproto-io = { version = "0.63.0", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.63.0", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.63.0", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.63.0", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.63.0", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.63.0", path = "crates/panproto-parse" }
+panproto-project = { version = "0.63.0", path = "crates/panproto-project" }
+panproto-git = { version = "0.63.0", path = "crates/panproto-git" }
+panproto-xrpc = { version = "0.63.0", path = "crates/panproto-xrpc" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:             0.62.0
+version:             0.63.0
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/python-grammars-all/pyproject.toml
+++ b/bindings/python-grammars-all/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.62,<0.63",
+    "panproto>=0.63,<0.64",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-data/pyproject.toml
+++ b/bindings/python-grammars-data/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.62,<0.63",
+    "panproto>=0.63,<0.64",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-devops/pyproject.toml
+++ b/bindings/python-grammars-devops/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.62,<0.63",
+    "panproto>=0.63,<0.64",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-functional/pyproject.toml
+++ b/bindings/python-grammars-functional/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # companion via the entry point declared below; without panproto
     # installed there is no consumer for the grammars this package
     # ships.
-    "panproto>=0.62,<0.63",
+    "panproto>=0.63,<0.64",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-jvm/pyproject.toml
+++ b/bindings/python-grammars-jvm/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.62,<0.63",
+    "panproto>=0.63,<0.64",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-mobile/pyproject.toml
+++ b/bindings/python-grammars-mobile/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.62,<0.63",
+    "panproto>=0.63,<0.64",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-music/pyproject.toml
+++ b/bindings/python-grammars-music/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.62,<0.63",
+    "panproto>=0.63,<0.64",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-scripting/pyproject.toml
+++ b/bindings/python-grammars-scripting/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.62,<0.63",
+    "panproto>=0.63,<0.64",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-systems/pyproject.toml
+++ b/bindings/python-grammars-systems/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.62,<0.63",
+    "panproto>=0.63,<0.64",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-web/pyproject.toml
+++ b/bindings/python-grammars-web/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.62,<0.63",
+    "panproto>=0.63,<0.64",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python/tests/test_native.py
+++ b/bindings/python/tests/test_native.py
@@ -1151,6 +1151,28 @@ class TestRepositoryDataAccess:
         # not an error.
         assert repo.data_at("HEAD") == []
 
+    def test_add_skip_verify_leaves_stage_pending(self, tmp_path) -> None:
+        repo = panproto.Repository.init(str(tmp_path / "repo"))
+        repo.add(self._schema(("a", "integer")))
+        repo.commit("v1", "alice <a@example.com>")
+
+        # skip_verify stages without running GAT migration validation:
+        # the derived migration is still recorded, but the stage is left
+        # pending.
+        idx = repo.add(
+            self._schema(("a", "integer"), ("b", "string")), skip_verify=True
+        )
+        assert idx["staged"]["validation"] == "pending"
+        assert idx["staged"]["migration_id"] is not None
+        # A default commit accepts the pending stage (non-blocking).
+        repo.commit("v2", "alice <a@example.com>")
+
+        # The default add still runs validation (not pending).
+        idx = repo.add(
+            self._schema(("a", "integer"), ("b", "string"), ("c", "string"))
+        )
+        assert idx["staged"]["validation"] == "valid"
+
     def test_data_at_reads_committed_data_without_moving_head(
         self, tmp_path
     ) -> None:

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-cli/src/cmd/vcs.rs
+++ b/crates/panproto-cli/src/cmd/vcs.rs
@@ -58,10 +58,21 @@ pub fn cmd_init(path: &Path, initial_branch: Option<&str>) -> Result<()> {
     Ok(())
 }
 
+/// Staging flags for [`cmd_add`], grouped so the entry point does not
+/// take an unwieldy run of boolean parameters.
+#[derive(Clone, Copy, Default)]
+pub struct AddFlags {
+    /// Show what would be staged without staging.
+    pub dry_run: bool,
+    /// Stage even if validation fails.
+    pub force: bool,
+    /// Skip GAT migration validation while staging (leaves the stage pending).
+    pub skip_verify: bool,
+}
+
 pub fn cmd_add(
     schema_path: &Path,
-    dry_run: bool,
-    force: bool,
+    flags: AddFlags,
     data_path: Option<&Path>,
     verbose: bool,
 ) -> Result<()> {
@@ -81,7 +92,7 @@ pub fn cmd_add(
         );
     };
 
-    if dry_run {
+    if flags.dry_run {
         println!(
             "Would stage schema from {} ({} vertices, {} edges)",
             schema_path.display(),
@@ -96,8 +107,11 @@ pub fn cmd_add(
     }
 
     let mut repo = open_repo()?;
-    if force {
-        match repo.add(&schema) {
+    let opts = vcs::AddOptions {
+        skip_verify: flags.skip_verify,
+    };
+    if flags.force {
+        match repo.add_with_options(&schema, &opts) {
             Ok(_) => {}
             Err(vcs::VcsError::ValidationFailed { .. }) => {
                 eprintln!("warning: schema has validation errors (--force overrides)");
@@ -105,7 +119,7 @@ pub fn cmd_add(
             Err(e) => return Err(e).into_diagnostic().wrap_err("failed to stage schema"),
         }
     } else {
-        repo.add(&schema)
+        repo.add_with_options(&schema, &opts)
             .into_diagnostic()
             .wrap_err("failed to stage schema")?;
     }

--- a/crates/panproto-cli/src/main.rs
+++ b/crates/panproto-cli/src/main.rs
@@ -217,6 +217,11 @@ enum Command {
         /// Stage data files alongside the schema.
         #[arg(long)]
         data: Option<PathBuf>,
+
+        /// Skip GAT migration validation while staging (leaves the stage
+        /// pending; the migration is still recorded).
+        #[arg(long)]
+        skip_verify: bool,
     },
 
     /// Create a new commit from staged changes.
@@ -1230,7 +1235,17 @@ fn dispatch(command: Command, verbose: bool) -> Result<()> {
             dry_run,
             force,
             data,
-        } => cmd::vcs::cmd_add(&schema, dry_run, force, data.as_deref(), verbose),
+            skip_verify,
+        } => cmd::vcs::cmd_add(
+            &schema,
+            cmd::vcs::AddFlags {
+                dry_run,
+                force,
+                skip_verify,
+            },
+            data.as_deref(),
+            verbose,
+        ),
         Command::Commit {
             message,
             author,

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.62.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-py/src/vcs.rs
+++ b/crates/panproto-py/src/vcs.rs
@@ -281,8 +281,28 @@ impl PyRepository {
     // -- Staging + commit --
 
     /// Stage a schema for the next commit.
-    fn add(&mut self, py: Python<'_>, schema: &PySchema) -> PyResult<Py<PyAny>> {
-        let index = self.inner.add(schema.inner.as_ref()).map_err(vcs_err)?;
+    ///
+    /// With ``skip_verify=True`` the derived migration is still recorded
+    /// but GAT migration validation is skipped and the stage is left
+    /// ``pending`` (an escape hatch for bulk historical VCS builds where
+    /// each version was already validated at its own release).
+    #[pyo3(signature = (schema, *, skip_verify=false))]
+    fn add(
+        &mut self,
+        py: Python<'_>,
+        schema: &PySchema,
+        skip_verify: bool,
+    ) -> PyResult<Py<PyAny>> {
+        let index = if skip_verify {
+            self.inner
+                .add_with_options(
+                    schema.inner.as_ref(),
+                    &panproto_core::vcs::AddOptions { skip_verify: true },
+                )
+                .map_err(vcs_err)?
+        } else {
+            self.inner.add(schema.inner.as_ref()).map_err(vcs_err)?
+        };
         convert::to_python(py, &index_to_value(&index))
     }
 

--- a/crates/panproto-py/src/vcs.rs
+++ b/crates/panproto-py/src/vcs.rs
@@ -287,12 +287,7 @@ impl PyRepository {
     /// ``pending`` (an escape hatch for bulk historical VCS builds where
     /// each version was already validated at its own release).
     #[pyo3(signature = (schema, *, skip_verify=false))]
-    fn add(
-        &mut self,
-        py: Python<'_>,
-        schema: &PySchema,
-        skip_verify: bool,
-    ) -> PyResult<Py<PyAny>> {
+    fn add(&mut self, py: Python<'_>, schema: &PySchema, skip_verify: bool) -> PyResult<Py<PyAny>> {
         let index = if skip_verify {
             self.inner
                 .add_with_options(

--- a/crates/panproto-vcs/src/lib.rs
+++ b/crates/panproto-vcs/src/lib.rs
@@ -67,7 +67,7 @@ pub use object::{
     CommitObject, CommitObjectBuilder, ComplementObject, DataSetObject, EditLogObject,
     FileSchemaObject, Object, SchemaTreeEntry, SchemaTreeObject, TagObject,
 };
-pub use repo::{CommitOptions, Repository};
+pub use repo::{AddOptions, CommitOptions, Repository};
 pub use store::{HeadState, ReflogEntry, Store};
 pub use tree::{
     assemble_from_files, assemble_schema, build_schema_tree, build_tree_from_leaves,

--- a/crates/panproto-vcs/src/repo.rs
+++ b/crates/panproto-vcs/src/repo.rs
@@ -50,6 +50,19 @@ pub struct CommitOptions {
     pub skip_verify: bool,
 }
 
+/// Options for staging a schema.
+#[derive(Clone, Debug, Default)]
+pub struct AddOptions {
+    /// Skip GAT migration validation and schema-equation checks while
+    /// staging. The migration is still derived and recorded; only the
+    /// (bounded model-checking) validation is skipped, and the stage is
+    /// left [`ValidationStatus::Pending`]. This is the escape hatch for
+    /// bulk historical VCS builds, where every version was already
+    /// validated at its own release and re-checking each `add` against
+    /// HEAD is the dominant cost.
+    pub skip_verify: bool,
+}
+
 /// A panproto repository backed by a filesystem store.
 #[allow(dead_code)]
 pub struct Repository {
@@ -126,28 +139,56 @@ impl Repository {
 
     /// Stage a schema for the next commit.
     ///
-    /// Computes the diff from HEAD's schema (if any), auto-derives a
-    /// migration, validates it, and writes the index.
+    /// Equivalent to calling [`add_with_options`](Self::add_with_options)
+    /// with default options (GAT migration validation enabled).
     ///
     /// # Errors
     ///
     /// Returns an error if the schema cannot be hashed or stored.
     pub fn add(&mut self, schema: &Schema) -> Result<Index, VcsError> {
+        self.add_with_options(schema, &AddOptions::default())
+    }
+
+    /// Stage a schema for the next commit, with options.
+    ///
+    /// Computes the diff from HEAD's schema (if any), auto-derives a
+    /// migration, and writes the index. When `options.skip_verify` is
+    /// `false` (the default), the derived migration and the staged
+    /// schema's equations are GAT-validated (a bounded model check).
+    /// When `true`, the migration is still derived and recorded but that
+    /// validation is skipped and the stage is left
+    /// [`ValidationStatus::Pending`]; a default [`commit`](Self::commit)
+    /// treats `Pending` as non-blocking. This lets a caller replaying
+    /// already-validated versions build a historical VCS without paying
+    /// the per-`add` model check.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the schema cannot be hashed or stored.
+    pub fn add_with_options(
+        &mut self,
+        schema: &Schema,
+        options: &AddOptions,
+    ) -> Result<Index, VcsError> {
         let schema_id = crate::tree::store_schema_as_tree(&mut self.store, schema.clone())?;
 
         let (migration_id, auto_derived, validation, gat_diagnostics) = match store::resolve_head(
             &self.store,
         )? {
             None => {
-                // First commit: no migration, but the schema is still
-                // checked against its protocol theory's equations.
-                let gat_diag = self.schema_equation_diagnostics(schema);
-                let validation = if gat_diag.has_errors() {
-                    ValidationStatus::Invalid(gat_diag.all_errors())
+                // First commit: no migration, but (unless skipping) the
+                // schema is checked against its protocol theory's equations.
+                if options.skip_verify {
+                    (None, false, ValidationStatus::Pending, None)
                 } else {
-                    ValidationStatus::Valid
-                };
-                (None, false, validation, Some(gat_diag))
+                    let gat_diag = self.schema_equation_diagnostics(schema);
+                    let validation = if gat_diag.has_errors() {
+                        ValidationStatus::Invalid(gat_diag.all_errors())
+                    } else {
+                        ValidationStatus::Valid
+                    };
+                    (None, false, validation, Some(gat_diag))
+                }
             }
             Some(head_id) => {
                 let head_commit = self.load_commit(head_id)?;
@@ -196,9 +237,9 @@ impl Repository {
                     }
                 }
 
-                // Run GAT-level validation on the derived migration and
-                // the staged schema's equations, stamping the migration
-                // with the source and target schema identities.
+                // Stamp the migration with the source and target schema
+                // identities, and (unless skipping) GAT-validate the
+                // derived migration and the staged schema's equations.
                 let mig_src_id = self
                     .store
                     .put(&Object::FlatSchema(Box::new(head_schema.clone())))?;
@@ -206,12 +247,23 @@ impl Repository {
                     .store
                     .put(&Object::FlatSchema(Box::new(schema.clone())))?;
 
-                let mut gat_diag =
-                    gat_validate::validate_migration(&head_schema, schema, &migration);
-                if let Some(note) = hom_rejection {
-                    gat_diag.migration_warnings.push(note);
-                }
-                gat_diag.extend(self.schema_equation_diagnostics(schema));
+                let (validation, gat_diagnostics) = if options.skip_verify {
+                    (ValidationStatus::Pending, None)
+                } else {
+                    let mut gat_diag =
+                        gat_validate::validate_migration(&head_schema, schema, &migration);
+                    if let Some(note) = hom_rejection {
+                        gat_diag.migration_warnings.push(note);
+                    }
+                    gat_diag.extend(self.schema_equation_diagnostics(schema));
+                    // If GAT validation found errors, mark as invalid.
+                    let validation = if gat_diag.has_errors() {
+                        ValidationStatus::Invalid(gat_diag.all_errors())
+                    } else {
+                        ValidationStatus::Valid
+                    };
+                    (validation, Some(gat_diag))
+                };
 
                 let migration = migration.with_endpoints(
                     Some(panproto_gat::Name::from(mig_src_id.to_string())),
@@ -223,14 +275,7 @@ impl Repository {
                     mapping: migration,
                 })?;
 
-                // If GAT validation found errors, mark as invalid.
-                let validation = if gat_diag.has_errors() {
-                    ValidationStatus::Invalid(gat_diag.all_errors())
-                } else {
-                    ValidationStatus::Valid
-                };
-
-                (Some(migration_id), true, validation, Some(gat_diag))
+                (Some(migration_id), true, validation, gat_diagnostics)
             }
         };
 
@@ -1081,6 +1126,54 @@ mod tests {
         assert_eq!(log.len(), 2);
         assert_eq!(log[0].message, "second");
         assert_eq!(log[1].message, "first");
+        Ok(())
+    }
+
+    #[test]
+    fn add_skip_verify_leaves_stage_pending_but_records_migration()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use crate::index::ValidationStatus;
+
+        let dir = tempfile::tempdir()?;
+        let mut repo = Repository::init(dir.path())?;
+
+        let s1 = make_schema(&[("a", "object")]);
+        repo.add(&s1)?;
+        repo.commit("first", "alice")?;
+
+        // Staged with skip_verify: the migration is still derived and
+        // recorded, but the (bounded model-checking) validation is skipped
+        // and the stage is left Pending.
+        let s2 = make_schema(&[("a", "object"), ("b", "string")]);
+        let index = repo.add_with_options(&s2, &AddOptions { skip_verify: true })?;
+        let staged = index.staged.as_ref().ok_or("nothing staged")?;
+        assert!(
+            matches!(staged.validation, ValidationStatus::Pending),
+            "skip_verify should leave the stage pending, got {:?}",
+            staged.validation
+        );
+        assert!(
+            staged.gat_diagnostics.is_none(),
+            "no diagnostics are computed when skipping"
+        );
+        assert!(
+            staged.migration_id.is_some(),
+            "the derived migration is still recorded"
+        );
+
+        // A default commit accepts a Pending stage (it is non-blocking).
+        repo.commit("second", "alice")?;
+        assert_eq!(repo.log(None)?.len(), 2);
+
+        // The default add path still runs validation (not Pending).
+        let s3 = make_schema(&[("a", "object"), ("b", "string"), ("c", "string")]);
+        let index = repo.add(&s3)?;
+        let staged = index.staged.as_ref().ok_or("nothing staged")?;
+        assert!(
+            !matches!(staged.validation, ValidationStatus::Pending),
+            "the default add must run validation, but the stage is Pending"
+        );
+        assert!(staged.gat_diagnostics.is_some());
         Ok(())
     }
 


### PR DESCRIPTION
Closes #239.

## Problem

`Repository::add` always ran GAT migration validation (a bounded model check) against HEAD on every staged schema, with no opt-out. `commit` has `skip_verify`; `add` had no equivalent. On a large (~800-vertex) schema this made each `add` past the first minutes long, so building a VCS of many historical versions in sequence (init, then add+commit each released version) was impractical.

## Fix

`add` now delegates to `add_with_options(schema, &AddOptions { skip_verify })`, mirroring `commit`'s existing `skip_verify`:

- `skip_verify` **unset** (default): unchanged; the derived migration and the staged schema's equations are GAT-validated.
- `skip_verify` **set**: the migration is still derived and recorded, but validation is skipped and the stage is left `ValidationStatus::Pending`. A default `commit` treats `Pending` as non-blocking, so a caller replaying already-validated released versions can build a historical VCS quickly.

The skipped calls are purely diagnostic; migration derivation, endpoint stamping, and the `Object::Migration` put all still run, so staging records the identical migration.

## Surface

Mirrors `commit`'s precedent exactly (core + Python + CLI; not WASM/C/Haskell, whose `vcs_add` uses a non-validating in-memory store):

- Rust: `Repository::add_with_options` + `AddOptions { skip_verify }` (exported from `panproto-vcs`).
- Python: `repo.add(schema, skip_verify=True)`.
- CLI: `schema add --skip-verify` (the add-behavior flags grouped into an `AddFlags` struct to stay under the bool-parameter lint).

## Testing

- New Rust test: a `skip_verify` add leaves the stage `Pending` with no diagnostics but still records the migration, and a default commit accepts it; a default add still validates.
- New Python test: `repo.add(schema, skip_verify=True)` yields `validation == "pending"`; a default add yields `"valid"`.
- `cargo nextest run --workspace`: 3303 passed. `fmt`, workspace `clippy -D warnings`, `doc`: clean. Python wheel test passes.
- Additive, so a 0.63.0 minor bump; version-consistency check passes.
