### PR TITLE
feat(protocols): per-file lexicon parsing for the VCS (#240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to panproto will be documented in this file.
 
+## [0.64.0] - 2026-07-23
+
+### Added
+
+- **`parse_schema_bundle_project`: per-file provenance for lexicon sets in the VCS** (`panproto-protocols`, `panproto`): parsing an ATProto lexicon *tree* had no path into the per-file project schema the version-control layer stores and diffs. `parse_schema_bundle("atproto", docs)` resolved cross-lexicon refs correctly but fused every document into one flat, path-less schema; `ProjectBuilder` / `parse_project` produced a per-file `ProjectSchema` but parsed `.json` as generic JSON, losing lexicon structure. So the atproto-correct parse and the per-file store did not compose. `parse_schema_bundle_project(protocol, docs)` (dispatching to `atproto::parse_lexicon_project`) parses the set as a bundle so in-set refs resolve to typed defs, then partitions the flat schema back by NSID ownership: each vertex and same-file edge returns to the document that declared it, while a ref that crosses documents becomes a `<path>::<name>`-prefixed cross-file edge. The result feeds `panproto_project::build_project_tree` to store a lexicon set as the per-file Merkle tree the VCS diffs incrementally; a round-trip test confirms two lexicons store as two per-file leaves and assemble back with the cross-file ref resolved to the typed def (not an opaque placeholder). Exposed in Python as `panproto.parse_schema_bundle_project(protocol, docs)` returning a `LexiconProject` (`.files()`, `.cross_file_edges()`); `bundle_project_protocols()` lists the protocols that retain per-file provenance (currently `atproto`). Closes #240.
+
 ## [0.63.0] - 2026-07-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "miette",
@@ -1924,7 +1924,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "ciborium",
  "git2",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "divan",
  "insta",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-dsl-eval"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "nickel-lang",
  "serde",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "divan",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "chumsky",
  "divan",
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "divan",
  "miette",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "divan",
  "git2",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "git2",
  "miette",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "cc",
  "divan",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2206,7 +2206,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2234,6 +2234,7 @@ dependencies = [
  "panproto-lens",
  "panproto-lens-dsl",
  "panproto-mig",
+ "panproto-project",
  "panproto-protocols",
  "panproto-schema",
  "panproto-vcs",
@@ -2247,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2273,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "divan",
  "insta",
@@ -2292,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "divan",
  "miette",
@@ -2311,7 +2312,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2328,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "divan",
  "memchr",
@@ -2350,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2372,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2383,12 +2384,13 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "smallvec 2.0.0-alpha.12",
  "thiserror",
 ]
 
 [[package]]
 name = "panproto-py"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2407,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2422,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "divan",
  "miette",
@@ -2441,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2465,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2479,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.63.0"
+version = "0.64.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -107,27 +107,27 @@ tree-sitter = "0.26"
 tree-sitter-tags = "0.26"
 
 # Workspace crates
-panproto-gat = { version = "0.63.0", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.63.0", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.63.0", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.63.0", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.63.0", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.63.0", path = "crates/panproto-lens" }
-panproto-dsl-eval = { version = "0.63.0", path = "crates/panproto-dsl-eval" }
-panproto-lens-dsl = { version = "0.63.0", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.63.0", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.63.0", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.63.0", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.63.0", path = "crates/panproto-core" }
-panproto-io = { version = "0.63.0", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.63.0", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.63.0", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.63.0", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.63.0", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.63.0", path = "crates/panproto-parse" }
-panproto-project = { version = "0.63.0", path = "crates/panproto-project" }
-panproto-git = { version = "0.63.0", path = "crates/panproto-git" }
-panproto-xrpc = { version = "0.63.0", path = "crates/panproto-xrpc" }
+panproto-gat = { version = "0.64.0", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.64.0", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.64.0", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.64.0", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.64.0", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.64.0", path = "crates/panproto-lens" }
+panproto-dsl-eval = { version = "0.64.0", path = "crates/panproto-dsl-eval" }
+panproto-lens-dsl = { version = "0.64.0", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.64.0", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.64.0", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.64.0", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.64.0", path = "crates/panproto-core" }
+panproto-io = { version = "0.64.0", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.64.0", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.64.0", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.64.0", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.64.0", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.64.0", path = "crates/panproto-parse" }
+panproto-project = { version = "0.64.0", path = "crates/panproto-project" }
+panproto-git = { version = "0.64.0", path = "crates/panproto-git" }
+panproto-xrpc = { version = "0.64.0", path = "crates/panproto-xrpc" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:             0.63.0
+version:             0.64.0
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/python-grammars-all/pyproject.toml
+++ b/bindings/python-grammars-all/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.63,<0.64",
+    "panproto>=0.64,<0.65",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-data/pyproject.toml
+++ b/bindings/python-grammars-data/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.63,<0.64",
+    "panproto>=0.64,<0.65",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-devops/pyproject.toml
+++ b/bindings/python-grammars-devops/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.63,<0.64",
+    "panproto>=0.64,<0.65",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-functional/pyproject.toml
+++ b/bindings/python-grammars-functional/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # companion via the entry point declared below; without panproto
     # installed there is no consumer for the grammars this package
     # ships.
-    "panproto>=0.63,<0.64",
+    "panproto>=0.64,<0.65",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-jvm/pyproject.toml
+++ b/bindings/python-grammars-jvm/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.63,<0.64",
+    "panproto>=0.64,<0.65",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-mobile/pyproject.toml
+++ b/bindings/python-grammars-mobile/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.63,<0.64",
+    "panproto>=0.64,<0.65",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-music/pyproject.toml
+++ b/bindings/python-grammars-music/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.63,<0.64",
+    "panproto>=0.64,<0.65",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-scripting/pyproject.toml
+++ b/bindings/python-grammars-scripting/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.63,<0.64",
+    "panproto>=0.64,<0.65",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-systems/pyproject.toml
+++ b/bindings/python-grammars-systems/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.63,<0.64",
+    "panproto>=0.64,<0.65",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-web/pyproject.toml
+++ b/bindings/python-grammars-web/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.63,<0.64",
+    "panproto>=0.64,<0.65",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python/src/panproto/__init__.py
+++ b/bindings/python/src/panproto/__init__.py
@@ -80,8 +80,10 @@ from panproto._native import (
     free_model,
     migrate_model,
     # Lexicon / schema-document parsing
+    LexiconProject,
     parse_atproto_lexicon,
     parse_schema_bundle,
+    parse_schema_bundle_project,
     parse_schema_document,
     parse_schema_source,
     theory_of,
@@ -253,8 +255,10 @@ __all__ = [
     "free_model",
     "migrate_model",
     # Lexicon / schema-document parsing
+    "LexiconProject",
     "parse_atproto_lexicon",
     "parse_schema_bundle",
+    "parse_schema_bundle_project",
     "parse_schema_document",
     "parse_schema_source",
     "theory_of",

--- a/bindings/python/tests/test_native.py
+++ b/bindings/python/tests/test_native.py
@@ -1072,6 +1072,57 @@ class TestLexiconParsing:
         assert bundled.vertex_count == direct.vertex_count
         assert bundled.edge_count == direct.edge_count
 
+    def test_parse_schema_bundle_project_partitions_and_lifts_cross_refs(self) -> None:
+        referring = {
+            "lexicon": 1,
+            "id": "local.bundle.referring",
+            "defs": {
+                "main": {
+                    "type": "record",
+                    "key": "tid",
+                    "record": {
+                        "type": "object",
+                        "required": ["anchor"],
+                        "properties": {
+                            "anchor": {
+                                "type": "ref",
+                                "ref": "local.bundle.defs#boundingBox",
+                            }
+                        },
+                    },
+                }
+            },
+        }
+        referenced = {
+            "lexicon": 1,
+            "id": "local.bundle.defs",
+            "defs": {
+                "boundingBox": {
+                    "type": "object",
+                    "required": ["x"],
+                    "properties": {"x": {"type": "integer"}},
+                }
+            },
+        }
+        project = panproto.parse_schema_bundle_project(
+            "atproto",
+            [("referring.json", referring), ("defs.json", referenced)],
+        )
+
+        # One schema per document, keyed by path.
+        assert set(project.file_paths()) == {"referring.json", "defs.json"}
+        files = dict(project.files())
+        assert files["defs.json"].vertex_count >= 1
+
+        # The cross-document ref is lifted into a path-prefixed cross-file
+        # edge on the referencing file, not left inside its schema.
+        cross = project.cross_file_edges()
+        assert "referring.json" in cross
+        edge = cross["referring.json"][0]
+        assert edge["kind"] == "ref"
+        assert edge["src"].startswith("referring.json::")
+        assert edge["tgt"].startswith("defs.json::")
+
     def test_parse_schema_bundle_unknown_protocol_raises(self) -> None:
         with pytest.raises(
             (ValueError, panproto.SchemaValidationError), match="no bundle parser"

--- a/bindings/python/tests/test_public_surface.py
+++ b/bindings/python/tests/test_public_surface.py
@@ -101,6 +101,7 @@ def test_core_public_symbols_are_reexported() -> None:
         # Python call turned a lexicon document into a Schema/Theory).
         "parse_atproto_lexicon",
         "parse_schema_bundle",
+        "parse_schema_bundle_project",
         "parse_schema_document",
         "parse_schema_source",
         "theory_of",

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.63.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-protocols/Cargo.toml
+++ b/crates/panproto-protocols/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 rustc-hash = { workspace = true }
 blake3 = { workspace = true }
+smallvec = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/panproto-protocols/src/lib.rs
+++ b/crates/panproto-protocols/src/lib.rs
@@ -107,6 +107,53 @@ pub const fn bundle_parser_protocols() -> &'static [&'static str] {
     &["atproto"]
 }
 
+/// Parse a set of schema documents into per-file schemas, keyed by path.
+///
+/// The result also carries the edges that cross document boundaries: the
+/// shape [`build_project_tree`](https://docs.rs/panproto-project)
+/// consumes to store a document set as the per-file tree the VCS diffs
+/// incrementally.
+///
+/// Where [`parse_schema_bundle`] fuses a document set into one flat
+/// [`Schema`], this keeps each document a separate schema, so a
+/// version-controlled lexicon set can reuse unchanged per-file object
+/// ids across commits. Dispatch normalizes an underscore key to its
+/// canonical hyphenated protocol name, matching [`parse_schema_bundle`].
+/// Only the protocols in [`bundle_project_protocols`] retain per-file
+/// provenance today; any other returns an error.
+///
+/// # Errors
+///
+/// Returns [`ProtocolError::Parse`] for a protocol with no per-file
+/// bundle parser, or the underlying parser's error.
+pub fn parse_schema_bundle_project(
+    protocol: &str,
+    docs: &[(std::path::PathBuf, serde_json::Value)],
+) -> Result<atproto::LexiconProject, ProtocolError> {
+    match protocol.replace('_', "-").as_str() {
+        "atproto" => {
+            let lexicon_docs: Vec<atproto::LexiconDoc> = docs
+                .iter()
+                .map(|(path, value)| atproto::LexiconDoc {
+                    path: path.clone(),
+                    value: value.clone(),
+                })
+                .collect();
+            atproto::parse_lexicon_project(&lexicon_docs)
+        }
+        other => Err(ProtocolError::Parse(format!(
+            "no per-file bundle parser registered for protocol {other:?}; supported: [\"atproto\"]"
+        ))),
+    }
+}
+
+/// Protocols whose bundle parse retains per-file provenance for the VCS
+/// (via [`parse_schema_bundle_project`]).
+#[must_use]
+pub const fn bundle_project_protocols() -> &'static [&'static str] {
+    &["atproto"]
+}
+
 /// Parse a single JSON schema *document* into a [`Schema`], dispatching
 /// on protocol name.
 ///

--- a/crates/panproto-protocols/src/web_document/atproto.rs
+++ b/crates/panproto-protocols/src/web_document/atproto.rs
@@ -10,9 +10,11 @@
 //! Edge kinds: record-schema, prop, items, variant, ref, self-ref.
 
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 
-use panproto_gat::{Sort, Theory, pushout_by_name};
-use panproto_schema::{EdgeRule, Protocol, Schema, SchemaBuilder};
+use panproto_gat::{Name, Sort, Theory, pushout_by_name};
+use panproto_schema::{Edge, EdgeRule, Protocol, Schema, SchemaBuilder};
+use smallvec::SmallVec;
 
 use crate::error::ProtocolError;
 use crate::theories;
@@ -198,6 +200,230 @@ pub fn parse_lexicon_bundle(docs: &[serde_json::Value]) -> Result<Schema, Protoc
 
     let schema = builder.build()?;
     Ok(schema)
+}
+
+/// One `ATProto` lexicon document tagged with the project-relative path
+/// it lives at.
+pub struct LexiconDoc {
+    /// Project-relative path of the lexicon file (e.g.
+    /// `annotation/annotationLayer.json`).
+    pub path: PathBuf,
+    /// The lexicon document.
+    pub value: serde_json::Value,
+}
+
+/// A lexicon set parsed with per-file provenance: each document's own
+/// schema plus the ref edges that cross document boundaries.
+///
+/// Where [`parse_lexicon_bundle`] fuses every document into one flat
+/// schema (correct, but with no per-file identity, so the version-control
+/// layer cannot store or diff it as the per-file tree it is built
+/// around), this keeps each document a separate schema and records
+/// cross-document refs as `<path>::<name>`-prefixed edges that project
+/// assembly adds verbatim. Feed `files` and `cross_file_edges` to
+/// `panproto_project::build_project_tree` to store a lexicon set as a
+/// per-file tree the VCS can diff incrementally.
+pub struct LexiconProject {
+    /// Each document's own schema (its owned defs as typed vertices),
+    /// keyed by the document's path.
+    pub files: Vec<(PathBuf, Schema)>,
+    /// Cross-file ref edges, keyed by the owning (source) file. Both
+    /// endpoints are already prefixed with their owning file's path, so
+    /// project assembly adds them without re-prefixing.
+    pub cross_file_edges: HashMap<PathBuf, Vec<Edge>>,
+}
+
+/// A vertex `vertex_id` is owned by the lexicon whose id is `doc_id`
+/// when it is that lexicon's `main` record (`vertex_id == doc_id`) or a
+/// sub-vertex under it (`doc_id` followed by a `#`, `:`, or `.`
+/// separator). Callers try the longest matching `doc_id` first so a
+/// document whose id is a prefix of another's does not steal its
+/// vertices.
+fn is_owned_by(vertex_id: &str, doc_id: &str) -> bool {
+    vertex_id == doc_id
+        || vertex_id
+            .strip_prefix(doc_id)
+            .is_some_and(|rest| rest.starts_with(['#', ':', '.']))
+}
+
+fn prefix_name(path: &std::path::Path, name: &str) -> Name {
+    Name::from(format!("{}::{}", path.display(), name).as_str())
+}
+
+/// Build a per-file schema holding only the vertices in `owned` and the
+/// edges in `internal`, recomputing the adjacency indices from the
+/// retained edges.
+fn retain_file_schema(m: &Schema, owned: &HashSet<Name>, internal: &HashSet<Edge>) -> Schema {
+    fn by_vertex<V: Clone>(map: &HashMap<Name, V>, owned: &HashSet<Name>) -> HashMap<Name, V> {
+        map.iter()
+            .filter(|(k, _)| owned.contains(*k))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
+
+    let edges: HashMap<Edge, Name> = m
+        .edges
+        .iter()
+        .filter(|(e, _)| internal.contains(*e))
+        .map(|(e, k)| (e.clone(), k.clone()))
+        .collect();
+
+    // Recompute adjacency indices from the retained edges.
+    let mut outgoing: HashMap<Name, SmallVec<Edge, 4>> = HashMap::new();
+    let mut incoming: HashMap<Name, SmallVec<Edge, 4>> = HashMap::new();
+    let mut between: HashMap<(Name, Name), SmallVec<Edge, 2>> = HashMap::new();
+    for edge in edges.keys() {
+        outgoing
+            .entry(edge.src.clone())
+            .or_default()
+            .push(edge.clone());
+        incoming
+            .entry(edge.tgt.clone())
+            .or_default()
+            .push(edge.clone());
+        between
+            .entry((edge.src.clone(), edge.tgt.clone()))
+            .or_default()
+            .push(edge.clone());
+    }
+
+    Schema {
+        protocol: m.protocol.clone(),
+        vertices: by_vertex(&m.vertices, owned),
+        edges,
+        hyper_edges: m.hyper_edges.clone(),
+        constraints: by_vertex(&m.constraints, owned),
+        required: by_vertex(&m.required, owned),
+        nsids: by_vertex(&m.nsids, owned),
+        entries: m
+            .entries
+            .iter()
+            .filter(|e| owned.contains(*e))
+            .cloned()
+            .collect(),
+        variants: by_vertex(&m.variants, owned),
+        orderings: m
+            .orderings
+            .iter()
+            .filter(|(e, _)| internal.contains(*e))
+            .map(|(e, p)| (e.clone(), *p))
+            .collect(),
+        recursion_points: by_vertex(&m.recursion_points, owned),
+        spans: m.spans.clone(),
+        usage_modes: m
+            .usage_modes
+            .iter()
+            .filter(|(e, _)| internal.contains(*e))
+            .map(|(e, u)| (e.clone(), u.clone()))
+            .collect(),
+        nominal: by_vertex(&m.nominal, owned),
+        coercions: m.coercions.clone(),
+        mergers: by_vertex(&m.mergers, owned),
+        defaults: by_vertex(&m.defaults, owned),
+        policies: m.policies.clone(),
+        outgoing,
+        incoming,
+        between,
+    }
+}
+
+/// Parse a set of `ATProto` lexicon documents into per-file schemas with
+/// cross-document refs resolved, retaining the per-file provenance the
+/// version-control layer needs.
+///
+/// The whole set is first parsed as a bundle (so every in-set `$ref`
+/// resolves to the referenced def's real, typed vertex), then the
+/// resulting flat schema is partitioned back by NSID ownership: each
+/// vertex and each same-file edge returns to the document that declared
+/// it, while an edge whose endpoints live in different documents becomes
+/// a cross-file edge with both endpoints prefixed by their owning file.
+/// A ref whose target is in no document of the set stays an opaque
+/// placeholder in the referencing file, exactly as [`parse_lexicon`]
+/// leaves it.
+///
+/// # Errors
+///
+/// Returns the same errors as [`parse_lexicon_bundle`]: a document
+/// missing `id` or `defs`, duplicate ids, or a schema-builder error.
+pub fn parse_lexicon_project(docs: &[LexiconDoc]) -> Result<LexiconProject, ProtocolError> {
+    let values: Vec<serde_json::Value> = docs.iter().map(|d| d.value.clone()).collect();
+    let monolith = parse_lexicon_bundle(&values)?;
+
+    // Document id -> path, longest id first so the longest-prefix match
+    // wins when one lexicon id is a prefix of another.
+    let mut doc_paths: Vec<(String, PathBuf)> = Vec::with_capacity(docs.len());
+    for d in docs {
+        let id = d
+            .value
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| ProtocolError::MissingField("id".into()))?;
+        doc_paths.push((id.to_string(), d.path.clone()));
+    }
+    doc_paths.sort_by_key(|(id, _)| std::cmp::Reverse(id.len()));
+
+    // Assign every vertex to the document that owns it.
+    let mut owner: HashMap<Name, PathBuf> = HashMap::new();
+    for vid in monolith.vertices.keys() {
+        if let Some((_, path)) = doc_paths.iter().find(|(id, _)| is_owned_by(vid, id)) {
+            owner.insert(vid.clone(), path.clone());
+        }
+    }
+    // An out-of-set ref target is an opaque placeholder owned by no
+    // document; keep it in the file that references it so it stays a
+    // (genuinely external) placeholder there rather than vanishing.
+    for edge in monolith.edges.keys() {
+        if !owner.contains_key(&edge.tgt) {
+            if let Some(src_path) = owner.get(&edge.src).cloned() {
+                owner.insert(edge.tgt.clone(), src_path);
+            }
+        }
+    }
+
+    // Partition edges into per-file internal sets and cross-file edges.
+    let mut internal: HashMap<PathBuf, HashSet<Edge>> = HashMap::new();
+    let mut cross_file_edges: HashMap<PathBuf, Vec<Edge>> = HashMap::new();
+    for edge in monolith.edges.keys() {
+        let (Some(src_path), Some(tgt_path)) = (owner.get(&edge.src), owner.get(&edge.tgt)) else {
+            continue;
+        };
+        if src_path == tgt_path {
+            internal
+                .entry(src_path.clone())
+                .or_default()
+                .insert(edge.clone());
+        } else {
+            let prefixed = Edge {
+                src: prefix_name(src_path, &edge.src),
+                tgt: prefix_name(tgt_path, &edge.tgt),
+                kind: edge.kind.clone(),
+                name: edge.name.as_ref().map(|n| prefix_name(src_path, n)),
+            };
+            cross_file_edges
+                .entry(src_path.clone())
+                .or_default()
+                .push(prefixed);
+        }
+    }
+
+    // Build each document's per-file schema from the vertices it owns and
+    // its internal edges, in input order for determinism.
+    let mut files: Vec<(PathBuf, Schema)> = Vec::with_capacity(docs.len());
+    for d in docs {
+        let owned: HashSet<Name> = owner
+            .iter()
+            .filter(|(_, p)| **p == d.path)
+            .map(|(v, _)| v.clone())
+            .collect();
+        let file_internal = internal.remove(&d.path).unwrap_or_default();
+        let schema = retain_file_schema(&monolith, &owned, &file_internal);
+        files.push((d.path.clone(), schema));
+    }
+
+    Ok(LexiconProject {
+        files,
+        cross_file_edges,
+    })
 }
 
 /// Register a vertex for every top-level def in one document.
@@ -1264,6 +1490,83 @@ mod tests {
                 }
             }),
         ]
+    }
+
+    /// `parse_lexicon_project` keeps per-file provenance: each document
+    /// becomes its own schema (with in-set refs resolved to typed defs),
+    /// and a cross-document ref is lifted out of the referencing file
+    /// into a path-prefixed cross-file edge.
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn lexicon_project_partitions_by_file_and_lifts_cross_refs() {
+        let docs = cross_file_docs();
+        let p1 = PathBuf::from("annotation/annotationLayer.json");
+        let p2 = PathBuf::from("defs.json");
+        let project = parse_lexicon_project(&[
+            LexiconDoc {
+                path: p1.clone(),
+                value: docs[0].clone(),
+            },
+            LexiconDoc {
+                path: p2.clone(),
+                value: docs[1].clone(),
+            },
+        ])
+        .expect("parse project should succeed");
+
+        assert_eq!(project.files.len(), 2, "one schema per document");
+
+        let file1 = &project
+            .files
+            .iter()
+            .find(|(p, _)| *p == p1)
+            .expect("annotationLayer file")
+            .1;
+        let file2 = &project
+            .files
+            .iter()
+            .find(|(p, _)| *p == p2)
+            .expect("defs file")
+            .1;
+
+        // The defs file owns the referenced def, typed as an object
+        // (resolved by the bundle pass, not left an opaque placeholder),
+        // and its own internal box -> boundingBox ref stays inside it.
+        assert_eq!(
+            &*file2.vertices["pub.layers.defs#spatioTemporalAnchor"].kind,
+            "object"
+        );
+        assert!(file2.vertices.contains_key("pub.layers.defs#boundingBox"));
+        assert!(
+            file2
+                .edges
+                .keys()
+                .any(|e| &*e.kind == "ref" && &*e.tgt == "pub.layers.defs#boundingBox"),
+            "the same-file box -> boundingBox ref must stay internal"
+        );
+
+        // The referencing file does not carry the sibling document's def:
+        // the cross-document ref was lifted out.
+        assert!(
+            !file1
+                .vertices
+                .contains_key("pub.layers.defs#spatioTemporalAnchor"),
+            "a cross-document def must not appear in the referencing file"
+        );
+
+        // The lifted ref is recorded as a cross-file edge with both
+        // endpoints prefixed by their owning file.
+        let cross = project
+            .cross_file_edges
+            .get(&p1)
+            .expect("cross-file edges for the referencing file");
+        assert!(
+            cross.iter().any(|e| &*e.kind == "ref"
+                && e.tgt
+                    .contains("defs.json::pub.layers.defs#spatioTemporalAnchor")
+                && e.src.starts_with("annotation/annotationLayer.json::")),
+            "expected a path-prefixed cross-file ref, got: {cross:?}"
+        );
     }
 
     /// Parsing one document alone leaves its cross-document ref target

--- a/crates/panproto-py/src/lexicon.rs
+++ b/crates/panproto-py/src/lexicon.rs
@@ -254,6 +254,118 @@ pub fn parse_schema_bundle(protocol: &str, docs: &Bound<'_, PyAny>) -> PyResult<
     })
 }
 
+/// Per-file lexicon schemas plus cross-file ref edges: the per-file
+/// provenance form of a lexicon set, retained for the version-control
+/// layer (where :func:`parse_schema_bundle` fuses the same documents
+/// into one flat schema with no per-file identity).
+#[pyclass(name = "LexiconProject", module = "panproto._native")]
+pub struct PyLexiconProject {
+    files: Vec<(String, Arc<panproto_core::schema::Schema>)>,
+    cross: Vec<(String, Vec<panproto_core::schema::Edge>)>,
+}
+
+#[pymethods]
+impl PyLexiconProject {
+    /// The per-file schemas as ``(path, Schema)`` pairs, in input order.
+    fn files(&self) -> Vec<(String, PySchema)> {
+        self.files
+            .iter()
+            .map(|(p, s)| (p.clone(), PySchema { inner: s.clone() }))
+            .collect()
+    }
+
+    /// The document paths, in input order.
+    fn file_paths(&self) -> Vec<String> {
+        self.files.iter().map(|(p, _)| p.clone()).collect()
+    }
+
+    /// Cross-file ref edges as ``{path: [{"src", "tgt", "kind", "name"}]}``.
+    /// Both endpoints are already prefixed with their owning file's path.
+    fn cross_file_edges(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let map: serde_json::Map<String, serde_json::Value> = self
+            .cross
+            .iter()
+            .map(|(path, edges)| {
+                let list: Vec<serde_json::Value> = edges
+                    .iter()
+                    .map(|e| {
+                        serde_json::json!({
+                            "src": e.src.as_ref(),
+                            "tgt": e.tgt.as_ref(),
+                            "kind": e.kind.as_ref(),
+                            "name": e.name.as_deref(),
+                        })
+                    })
+                    .collect();
+                (path.clone(), serde_json::Value::Array(list))
+            })
+            .collect();
+        crate::convert::to_python(py, &serde_json::Value::Object(map))
+    }
+
+    fn __repr__(&self) -> String {
+        format!("LexiconProject({} files)", self.files.len())
+    }
+}
+
+/// Parse a set of lexicon documents into per-file schemas with per-file
+/// provenance, resolving cross-document refs.
+///
+/// Where :func:`parse_schema_bundle` fuses a lexicon set into one flat
+/// schema, this keeps each document a separate schema plus the ref edges
+/// that cross document boundaries (endpoints already prefixed with their
+/// owning file's path), so a lexicon set can be stored and diffed as the
+/// per-file tree the version-control layer is built around.
+///
+/// Parameters
+/// ----------
+/// protocol : str
+///     The protocol the documents are written in (currently ``atproto``).
+/// docs : list of (str, dict | str)
+///     ``(path, document)`` pairs. ``path`` is the project-relative file
+///     path; ``document`` is a parsed dict or a raw JSON string.
+///
+/// Returns
+/// -------
+/// LexiconProject
+///     Per-file schemas (:meth:`LexiconProject.files`) and cross-file
+///     edges (:meth:`LexiconProject.cross_file_edges`).
+///
+/// Raises
+/// ------
+/// `ValueError`
+///     If ``protocol`` has no per-file bundle parser, or a document is a
+///     string that is not valid JSON.
+#[pyfunction]
+pub fn parse_schema_bundle_project(
+    protocol: &str,
+    docs: &Bound<'_, PyAny>,
+) -> PyResult<PyLexiconProject> {
+    let mut pairs: Vec<(std::path::PathBuf, serde_json::Value)> = Vec::new();
+    for item in docs.try_iter()? {
+        let item = item?;
+        let path: String = item.get_item(0)?.extract()?;
+        let value = json_from_py(&item.get_item(1)?)?;
+        pairs.push((std::path::PathBuf::from(path), value));
+    }
+
+    let project = panproto_core::protocols::parse_schema_bundle_project(protocol, &pairs)
+        .map_err(|e| SchemaValidationError::new_err(format!("bundle project parse failed: {e}")))?;
+
+    let files = project
+        .files
+        .into_iter()
+        .map(|(p, s)| (p.display().to_string(), Arc::new(s)))
+        .collect();
+    let cross = project
+        .cross_file_edges
+        .into_iter()
+        .map(|(p, edges)| (p.display().to_string(), edges))
+        .collect();
+
+    Ok(PyLexiconProject { files, cross })
+}
+
 /// Extract the GAT theory a schema instantiates.
 ///
 /// The induced theory has one sort per vertex and one unary operation per
@@ -289,6 +401,8 @@ pub fn register(parent: &Bound<'_, PyModule>) -> PyResult<()> {
     parent.add_function(wrap_pyfunction!(parse_schema_document, parent)?)?;
     parent.add_function(wrap_pyfunction!(parse_schema_source, parent)?)?;
     parent.add_function(wrap_pyfunction!(parse_schema_bundle, parent)?)?;
+    parent.add_function(wrap_pyfunction!(parse_schema_bundle_project, parent)?)?;
     parent.add_function(wrap_pyfunction!(theory_of, parent)?)?;
+    parent.add_class::<PyLexiconProject>()?;
     Ok(())
 }

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -19,6 +19,7 @@ panproto-lens = { path = "../../crates/panproto-lens" }
 panproto-lens-dsl = { path = "../../crates/panproto-lens-dsl" }
 panproto-check = { path = "../../crates/panproto-check" }
 panproto-protocols = { path = "../../crates/panproto-protocols" }
+panproto-project = { path = "../../crates/panproto-project" }
 panproto-vcs = { path = "../../crates/panproto-vcs" }
 panproto-core = { path = "../../crates/panproto-core" }
 panproto-expr = { path = "../../crates/panproto-expr" }

--- a/tests/integration/tests/issue_240_lexicon_project.rs
+++ b/tests/integration/tests/issue_240_lexicon_project.rs
@@ -1,0 +1,117 @@
+//! Regression test for issue #240.
+//!
+//! An ATProto lexicon set must be reachable as the per-file project tree
+//! `panproto-vcs` is built around: `parse_schema_bundle_project` parses
+//! each lexicon into its own schema (with in-set refs resolved to typed
+//! defs) plus path-prefixed cross-file edges, and `build_project_tree`
+//! stores that as a per-file Merkle tree that assembles back to a flat
+//! schema with the cross-file ref resolved.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use panproto_project::build_project_tree;
+use panproto_protocols::parse_schema_bundle_project;
+use panproto_schema::Schema;
+use panproto_vcs::{
+    FileSchemaObject, MemStore, assemble_schema, project_coproduct_protocol, walk_tree,
+};
+
+/// A record lexicon whose one field is a ref into a sibling `defs`
+/// lexicon, which in turn refs a def within itself.
+fn cross_file_docs() -> Vec<serde_json::Value> {
+    vec![
+        serde_json::json!({
+            "lexicon": 1,
+            "id": "pub.layers.annotation.annotationLayer",
+            "defs": {
+                "main": {
+                    "type": "record",
+                    "record": {
+                        "type": "object",
+                        "required": ["anchor"],
+                        "properties": {
+                            "anchor": {
+                                "type": "ref",
+                                "ref": "pub.layers.defs#spatioTemporalAnchor"
+                            }
+                        }
+                    }
+                }
+            }
+        }),
+        serde_json::json!({
+            "lexicon": 1,
+            "id": "pub.layers.defs",
+            "defs": {
+                "spatioTemporalAnchor": {
+                    "type": "object",
+                    "required": ["box"],
+                    "properties": { "box": {"type": "ref", "ref": "#boundingBox"} }
+                },
+                "boundingBox": {
+                    "type": "object",
+                    "required": ["x", "y"],
+                    "properties": { "x": {"type": "integer"}, "y": {"type": "integer"} }
+                }
+            }
+        }),
+    ]
+}
+
+#[test]
+fn lexicon_project_round_trips_through_the_vcs_tree() -> Result<(), Box<dyn std::error::Error>> {
+    let docs = cross_file_docs();
+    let p1 = PathBuf::from("annotation/annotationLayer.json");
+    let p2 = PathBuf::from("defs.json");
+
+    let project = parse_schema_bundle_project(
+        "atproto",
+        &[(p1.clone(), docs[0].clone()), (p2.clone(), docs[1].clone())],
+    )?;
+
+    let files: HashMap<PathBuf, Schema> = project.files.iter().cloned().collect();
+    let protocols: HashMap<PathBuf, String> = files
+        .keys()
+        .map(|p| (p.clone(), "atproto".to_string()))
+        .collect();
+
+    let mut store = MemStore::new();
+    let root = build_project_tree(&mut store, &files, &protocols, &project.cross_file_edges)?;
+
+    // The tree stores exactly one per-file atproto leaf per lexicon.
+    let mut leaves: Vec<String> = Vec::new();
+    walk_tree(&store, &root, |path, file: &FileSchemaObject| {
+        assert_eq!(file.protocol, "atproto", "each leaf is an atproto schema");
+        leaves.push(path.to_string_lossy().into_owned());
+        Ok(())
+    })?;
+    leaves.sort();
+    assert_eq!(leaves.len(), 2, "one leaf per lexicon file, got {leaves:?}");
+
+    // Assembling the tree resolves the cross-file ref to the typed def.
+    let proto = project_coproduct_protocol();
+    let assembled = assemble_schema(&store, &root, &proto)?;
+
+    let anchor_key = "defs.json::pub.layers.defs#spatioTemporalAnchor";
+    let anchor = assembled.vertices.get(anchor_key).ok_or_else(|| {
+        format!(
+            "assembled schema is missing {anchor_key}; vertices: {:?}",
+            assembled.vertices.keys().collect::<Vec<_>>()
+        )
+    })?;
+    assert_eq!(
+        &*anchor.kind, "object",
+        "the cross-file ref must resolve to the typed def, not an opaque placeholder"
+    );
+
+    // A ref edge crosses from the referencing file to that resolved def.
+    assert!(
+        assembled.edges.keys().any(|e| &*e.kind == "ref"
+            && e.src.starts_with("annotation/annotationLayer.json::")
+            && &*e.tgt == anchor_key),
+        "expected the resolved cross-file ref edge in the assembled schema"
+    );
+
+    Ok(())
+}

--- a/tests/integration/tests/issue_240_lexicon_project.rs
+++ b/tests/integration/tests/issue_240_lexicon_project.rs
@@ -1,6 +1,6 @@
 //! Regression test for issue #240.
 //!
-//! An ATProto lexicon set must be reachable as the per-file project tree
+//! An `ATProto` lexicon set must be reachable as the per-file project tree
 //! `panproto-vcs` is built around: `parse_schema_bundle_project` parses
 //! each lexicon into its own schema (with in-set refs resolved to typed
 //! defs) plus path-prefixed cross-file edges, and `build_project_tree`
@@ -62,12 +62,16 @@ fn cross_file_docs() -> Vec<serde_json::Value> {
 #[test]
 fn lexicon_project_round_trips_through_the_vcs_tree() -> Result<(), Box<dyn std::error::Error>> {
     let docs = cross_file_docs();
-    let p1 = PathBuf::from("annotation/annotationLayer.json");
-    let p2 = PathBuf::from("defs.json");
 
     let project = parse_schema_bundle_project(
         "atproto",
-        &[(p1.clone(), docs[0].clone()), (p2.clone(), docs[1].clone())],
+        &[
+            (
+                PathBuf::from("annotation/annotationLayer.json"),
+                docs[0].clone(),
+            ),
+            (PathBuf::from("defs.json"), docs[1].clone()),
+        ],
     )?;
 
     let files: HashMap<PathBuf, Schema> = project.files.iter().cloned().collect();


### PR DESCRIPTION
Closes #240. Stacked on #241 (base: `feat/vcs-add-skip-verify`); retarget to `main` once that merges.

## Problem

There was no path to parse an ATProto lexicon *tree* into the per-file project schema `panproto-vcs` is built around:
- `parse_schema_bundle("atproto", docs)` resolves cross-lexicon refs correctly but fuses every document into one monolithic, path-less `Schema`.
- `ProjectBuilder` / `parse_project` produces a per-file `ProjectSchema` but parses `.json` as generic JSON, losing lexicon structure and cross-refs.

So the atproto-correct parse and the per-file store did not compose, and a lexicon set could not be version-controlled per-file.

## Fix

`parse_schema_bundle_project(protocol, docs)` (in `panproto-protocols`, dispatching to `atproto::parse_lexicon_project`):
1. Parses the whole set as a bundle, so every in-set `$ref` resolves to the referenced def's real, typed vertex.
2. Partitions that flat schema back by NSID ownership: each vertex and same-file edge returns to the document that declared it; a ref crossing documents becomes a `<path>::<name>`-prefixed cross-file edge; an out-of-set ref stays an opaque placeholder in the referencing file.

The result (`LexiconProject { files, cross_file_edges }`) feeds `panproto_project::build_project_tree` with **no VCS changes** to store a lexicon set as the per-file Merkle tree the VCS diffs incrementally.

All logic stays in `panproto-protocols`; the generic crates and the genericity guardrail are untouched.

## Surface

- Rust: `parse_lexicon_project`, `parse_schema_bundle_project`, `bundle_project_protocols` (re-exported via `panproto-core::protocols`).
- Python: `panproto.parse_schema_bundle_project(protocol, docs)` returning a `LexiconProject` (`.files()`, `.cross_file_edges()`, `.file_paths()`).

## Testing

- Unit (`panproto-protocols`): a two-lexicon set partitions into per-file schemas; the referenced def is typed in its own file; the same-file ref stays internal; the cross-doc ref is lifted to a path-prefixed cross-file edge.
- Integration (`tests/integration`): the round-trip `parse_schema_bundle_project` → `build_project_tree` → `assemble_schema` stores two per-file atproto leaves and reassembles with the cross-file ref resolved to the typed def (not a placeholder).
- Python: the binding partitions and lifts as expected; the public-surface test is updated.
- `cargo nextest run --workspace`, `fmt`, workspace `clippy -D warnings`, `doc`: green. Python wheel tests pass.
- Additive, so a 0.64.0 minor bump.

## Follow-up

Wiring the per-file tree into the commit porcelain (the Python `Repository.add` and the CLI directory `add`, which currently flatten *all* projects, not just lexicons) is a separate, protocol-agnostic change; this PR provides and proves the composition path that porcelain would call.
