### PR TITLE
feat(vcs): wire per-file project trees into add porcelain (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to panproto will be documented in this file.
 
+## [0.65.0] - 2026-07-23
+
+### Added
+
+- **Per-file project trees reach the VCS commit porcelain** (`panproto-vcs`, `schema`, `panproto`): directory staging and the Python repository binding previously flattened a multi-file project into one schema before writing the index. This staging-flattening gap discarded the tree root produced by `ProjectBuilder::build_tree` or `build_project_tree`, so a one-file edit forced the next commit to realign the whole schema instead of reusing every unchanged file object. `Repository::add_tree` and `add_tree_with_options` now assemble an existing tree for migration derivation and validation while retaining its root in the index and commit. `schema add <dir>` uses this path for parsed source projects and manifest-declared bundle protocols, including ATProto lexicon sets with cross-file references; Python exposes the same path as `Repository.add_project(project, skip_verify=False)`. Regression tests confirm that a changed file receives a new object ID while its unchanged sibling retains the old one. Closes #243.
+
 ## [0.64.0] - 2026-07-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "anyhow",
  "miette",
@@ -1924,7 +1924,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "ciborium",
  "git2",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "divan",
  "insta",
@@ -1960,12 +1960,13 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "assert_cmd",
  "blake3",
  "clap",
  "git2",
+ "globset",
  "miette",
  "panproto-core",
  "panproto-git",
@@ -1985,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2009,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-dsl-eval"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "nickel-lang",
  "serde",
@@ -2021,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "divan",
  "proptest",
@@ -2033,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "chumsky",
  "divan",
@@ -2044,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "divan",
  "miette",
@@ -2058,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2069,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "divan",
  "git2",
@@ -2088,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "git2",
  "miette",
@@ -2104,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "cc",
  "divan",
@@ -2116,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2125,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2134,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2143,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2152,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2161,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2170,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2179,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2188,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2197,7 +2198,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2206,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2223,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2248,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2274,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "divan",
  "insta",
@@ -2293,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "divan",
  "miette",
@@ -2312,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2329,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "divan",
  "memchr",
@@ -2351,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2373,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2390,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2409,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2424,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "divan",
  "miette",
@@ -2443,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2467,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2481,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.64.0"
+version = "0.65.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -107,27 +107,27 @@ tree-sitter = "0.26"
 tree-sitter-tags = "0.26"
 
 # Workspace crates
-panproto-gat = { version = "0.64.0", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.64.0", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.64.0", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.64.0", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.64.0", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.64.0", path = "crates/panproto-lens" }
-panproto-dsl-eval = { version = "0.64.0", path = "crates/panproto-dsl-eval" }
-panproto-lens-dsl = { version = "0.64.0", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.64.0", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.64.0", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.64.0", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.64.0", path = "crates/panproto-core" }
-panproto-io = { version = "0.64.0", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.64.0", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.64.0", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.64.0", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.64.0", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.64.0", path = "crates/panproto-parse" }
-panproto-project = { version = "0.64.0", path = "crates/panproto-project" }
-panproto-git = { version = "0.64.0", path = "crates/panproto-git" }
-panproto-xrpc = { version = "0.64.0", path = "crates/panproto-xrpc" }
+panproto-gat = { version = "0.65.0", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.65.0", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.65.0", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.65.0", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.65.0", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.65.0", path = "crates/panproto-lens" }
+panproto-dsl-eval = { version = "0.65.0", path = "crates/panproto-dsl-eval" }
+panproto-lens-dsl = { version = "0.65.0", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.65.0", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.65.0", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.65.0", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.65.0", path = "crates/panproto-core" }
+panproto-io = { version = "0.65.0", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.65.0", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.65.0", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.65.0", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.65.0", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.65.0", path = "crates/panproto-parse" }
+panproto-project = { version = "0.65.0", path = "crates/panproto-project" }
+panproto-git = { version = "0.65.0", path = "crates/panproto-git" }
+panproto-xrpc = { version = "0.65.0", path = "crates/panproto-xrpc" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:             0.64.0
+version:             0.65.0
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/python-grammars-all/pyproject.toml
+++ b/bindings/python-grammars-all/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.64,<0.65",
+    "panproto>=0.65,<0.66",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-data/pyproject.toml
+++ b/bindings/python-grammars-data/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.64,<0.65",
+    "panproto>=0.65,<0.66",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-devops/pyproject.toml
+++ b/bindings/python-grammars-devops/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.64,<0.65",
+    "panproto>=0.65,<0.66",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-functional/pyproject.toml
+++ b/bindings/python-grammars-functional/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # companion via the entry point declared below; without panproto
     # installed there is no consumer for the grammars this package
     # ships.
-    "panproto>=0.64,<0.65",
+    "panproto>=0.65,<0.66",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-jvm/pyproject.toml
+++ b/bindings/python-grammars-jvm/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.64,<0.65",
+    "panproto>=0.65,<0.66",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-mobile/pyproject.toml
+++ b/bindings/python-grammars-mobile/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.64,<0.65",
+    "panproto>=0.65,<0.66",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-music/pyproject.toml
+++ b/bindings/python-grammars-music/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.64,<0.65",
+    "panproto>=0.65,<0.66",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-scripting/pyproject.toml
+++ b/bindings/python-grammars-scripting/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.64,<0.65",
+    "panproto>=0.65,<0.66",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-systems/pyproject.toml
+++ b/bindings/python-grammars-systems/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.64,<0.65",
+    "panproto>=0.65,<0.66",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-web/pyproject.toml
+++ b/bindings/python-grammars-web/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.64,<0.65",
+    "panproto>=0.65,<0.66",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python/tests/test_native.py
+++ b/bindings/python/tests/test_native.py
@@ -1123,6 +1123,59 @@ class TestLexiconParsing:
         assert edge["src"].startswith("referring.json::")
         assert edge["tgt"].startswith("defs.json::")
 
+    def test_repository_add_project_stages_per_file_tree(self, tmp_path) -> None:
+        referenced = {
+            "lexicon": 1,
+            "id": "local.bundle.defs",
+            "defs": {
+                "target": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string"}},
+                }
+            },
+        }
+
+        def referring(*, required: bool) -> dict:
+            record = {
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "ref",
+                        "ref": "local.bundle.defs#target",
+                    }
+                },
+            }
+            if required:
+                record["required"] = ["target"]
+            return {
+                "lexicon": 1,
+                "id": "local.bundle.referring",
+                "defs": {
+                    "main": {
+                        "type": "record",
+                        "key": "tid",
+                        "record": record,
+                    }
+                },
+            }
+
+        repo = panproto.Repository.init(str(tmp_path / "repo"))
+        first = panproto.parse_schema_bundle_project(
+            "atproto",
+            [("referring.json", referring(required=False)), ("defs.json", referenced)],
+        )
+        first_index = repo.add_project(first, skip_verify=True)
+        first_root = first_index["staged"]["schema_id"]
+        repo.commit("first", "alice <a@example.com>")
+
+        second = panproto.parse_schema_bundle_project(
+            "atproto",
+            [("referring.json", referring(required=True)), ("defs.json", referenced)],
+        )
+        second_index = repo.add_project(second, skip_verify=True)
+        assert second_index["staged"]["schema_id"] != first_root
+        assert second_index["staged"]["migration_id"] is not None
+
     def test_parse_schema_bundle_unknown_protocol_raises(self) -> None:
         with pytest.raises(
             (ValueError, panproto.SchemaValidationError), match="no bundle parser"

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-cli/Cargo.toml
+++ b/crates/panproto-cli/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = { workspace = true }
 smallvec = { workspace = true }
 rustc-hash = { workspace = true }
 blake3 = { workspace = true }
+globset = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/panproto-cli/src/cmd/vcs.rs
+++ b/crates/panproto-cli/src/cmd/vcs.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use miette::{Context, IntoDiagnostic, Result};
 use panproto_core::{
-    schema::Schema,
+    schema::{Edge, Schema},
     vcs::{self, Store as _},
 };
 
@@ -70,21 +70,75 @@ pub struct AddFlags {
     pub skip_verify: bool,
 }
 
+enum AddSource {
+    Schema(Box<Schema>),
+    Project(Box<DirectoryProject>),
+}
+
+enum DirectoryProject {
+    Parsed(panproto_project::ProjectBuilder),
+    Bundle {
+        files: HashMap<PathBuf, Schema>,
+        protocols: HashMap<PathBuf, String>,
+        cross_file_edges: HashMap<PathBuf, Vec<Edge>>,
+    },
+}
+
+impl DirectoryProject {
+    fn build_tree<S: vcs::Store>(
+        self,
+        store: &mut S,
+    ) -> Result<panproto_project::ProjectSchemaTree> {
+        match self {
+            Self::Parsed(builder) => builder.build_tree(store).into_diagnostic(),
+            Self::Bundle {
+                files,
+                protocols,
+                cross_file_edges,
+            } => {
+                let root_id = panproto_project::build_project_tree(
+                    store,
+                    &files,
+                    &protocols,
+                    &cross_file_edges,
+                )
+                .into_diagnostic()?;
+                Ok(panproto_project::ProjectSchemaTree {
+                    root_id,
+                    protocol_map: protocols,
+                })
+            }
+        }
+    }
+
+    fn build_schema(self) -> Result<Schema> {
+        match self {
+            Self::Parsed(builder) => Ok(builder.build().into_diagnostic()?.schema),
+            bundle @ Self::Bundle { .. } => {
+                let mut store = vcs::MemStore::new();
+                let tree = bundle.build_tree(&mut store)?;
+                vcs::assemble_schema(&store, &tree.root_id, &vcs::project_coproduct_protocol())
+                    .into_diagnostic()
+            }
+        }
+    }
+}
+
 pub fn cmd_add(
     schema_path: &Path,
     flags: AddFlags,
     data_path: Option<&Path>,
     verbose: bool,
 ) -> Result<()> {
-    let schema: Schema = if schema_path.extension().is_some_and(|e| e == "json") {
+    let source = if schema_path.extension().is_some_and(|e| e == "json") && schema_path.is_file() {
         // JSON schema file: existing behavior.
-        load_json(schema_path)?
+        AddSource::Schema(Box::new(load_json(schema_path)?))
     } else if schema_path.is_dir() {
-        // Directory: parse as project, produce unified schema.
-        parse_directory_to_schema(schema_path, verbose)?
+        // Directory: retain one schema-tree leaf per source file.
+        AddSource::Project(Box::new(parse_directory_project(schema_path, verbose)?))
     } else if schema_path.is_file() {
         // Single source file: parse via tree-sitter.
-        parse_file_to_schema(schema_path, verbose)?
+        AddSource::Schema(Box::new(parse_file_to_schema(schema_path, verbose)?))
     } else {
         miette::bail!(
             "path {} does not exist or is not a file/directory",
@@ -93,6 +147,10 @@ pub fn cmd_add(
     };
 
     if flags.dry_run {
+        let schema = match source {
+            AddSource::Schema(schema) => *schema,
+            AddSource::Project(project) => (*project).build_schema()?,
+        };
         println!(
             "Would stage schema from {} ({} vertices, {} edges)",
             schema_path.display(),
@@ -110,8 +168,15 @@ pub fn cmd_add(
     let opts = vcs::AddOptions {
         skip_verify: flags.skip_verify,
     };
+    let stage_result = match source {
+        AddSource::Schema(schema) => repo.add_with_options(&schema, &opts),
+        AddSource::Project(project) => {
+            let tree = (*project).build_tree(repo.store_mut())?;
+            repo.add_tree_with_options(tree.root_id, &opts)
+        }
+    };
     if flags.force {
-        match repo.add_with_options(&schema, &opts) {
+        match stage_result {
             Ok(_) => {}
             Err(vcs::VcsError::ValidationFailed { .. }) => {
                 eprintln!("warning: schema has validation errors (--force overrides)");
@@ -119,7 +184,7 @@ pub fn cmd_add(
             Err(e) => return Err(e).into_diagnostic().wrap_err("failed to stage schema"),
         }
     } else {
-        repo.add_with_options(&schema, &opts)
+        stage_result
             .into_diagnostic()
             .wrap_err("failed to stage schema")?;
     }
@@ -158,9 +223,15 @@ fn parse_file_to_schema(path: &Path, verbose: bool) -> Result<Schema> {
     Ok(schema)
 }
 
-/// Parse a directory into a unified project schema.
-fn parse_directory_to_schema(dir: &Path, verbose: bool) -> Result<Schema> {
+/// Parse a directory while retaining per-file schema provenance.
+fn parse_directory_project(dir: &Path, verbose: bool) -> Result<DirectoryProject> {
     let config = panproto_project::config::load_config(dir).into_diagnostic()?;
+    if let Some(ref cfg) = config
+        && let Some(protocol) = bundle_protocol(cfg)
+    {
+        return parse_bundle_project(dir, cfg, protocol, verbose);
+    }
+
     let mut builder = match config {
         Some(ref cfg) => {
             panproto_project::ProjectBuilder::with_config(cfg, dir).into_diagnostic()?
@@ -171,8 +242,87 @@ fn parse_directory_to_schema(dir: &Path, verbose: bool) -> Result<Schema> {
     if verbose {
         eprintln!("Scanned {} files", builder.file_count());
     }
-    let project = builder.build().into_diagnostic()?;
-    Ok(project.schema)
+    Ok(DirectoryProject::Parsed(builder))
+}
+
+fn bundle_protocol(config: &panproto_project::ProjectConfig) -> Option<&str> {
+    let protocol = config.package.first()?.protocol.as_deref()?;
+    let normalized = protocol.replace('_', "-");
+    (config.package.iter().all(|package| {
+        package
+            .protocol
+            .as_deref()
+            .is_some_and(|other| other.replace('_', "-") == normalized)
+    }) && panproto_core::protocols::bundle_project_protocols().contains(&normalized.as_str()))
+    .then_some(protocol)
+}
+
+fn parse_bundle_project(
+    dir: &Path,
+    config: &panproto_project::ProjectConfig,
+    protocol: &str,
+    verbose: bool,
+) -> Result<DirectoryProject> {
+    let excludes = panproto_project::config::compile_excludes(dir, &config.workspace.exclude)
+        .into_diagnostic()?;
+    let mut paths = Vec::new();
+    for package in &config.package {
+        collect_bundle_files(dir, &dir.join(&package.path), &excludes, &mut paths)?;
+    }
+    paths.sort();
+    paths.dedup();
+
+    let mut docs = Vec::with_capacity(paths.len());
+    for path in paths {
+        let value = load_json(&path)?;
+        let relative = path.strip_prefix(dir).unwrap_or(&path).to_path_buf();
+        docs.push((relative, value));
+    }
+    if verbose {
+        eprintln!("Scanned {} files as {protocol}", docs.len());
+    }
+
+    let project = panproto_core::protocols::parse_schema_bundle_project(protocol, &docs)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to parse {protocol} project"))?;
+    let files: HashMap<PathBuf, Schema> = project.files.into_iter().collect();
+    let normalized = protocol.replace('_', "-");
+    let protocols = files
+        .keys()
+        .map(|path| (path.clone(), normalized.clone()))
+        .collect();
+    Ok(DirectoryProject::Bundle {
+        files,
+        protocols,
+        cross_file_edges: project.cross_file_edges,
+    })
+}
+
+fn collect_bundle_files(
+    base: &Path,
+    dir: &Path,
+    excludes: &globset::GlobSet,
+    paths: &mut Vec<PathBuf>,
+) -> Result<()> {
+    for entry in std::fs::read_dir(dir).into_diagnostic()? {
+        let entry = entry.into_diagnostic()?;
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with('.') || excludes.is_match(&path) {
+            continue;
+        }
+        if path.is_dir() {
+            collect_bundle_files(base, &path, excludes, paths)?;
+        } else if path
+            .extension()
+            .is_some_and(|extension| extension == "json")
+            && path.starts_with(base)
+        {
+            paths.push(path);
+        }
+    }
+    Ok(())
 }
 
 /// Write a file hash manifest to `.panproto/file_hashes.json`.

--- a/crates/panproto-cli/tests/cli_workflows.rs
+++ b/crates/panproto-cli/tests/cli_workflows.rs
@@ -7,6 +7,7 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use std::collections::HashMap;
 use std::path::Path;
 
 // ---------------------------------------------------------------------------
@@ -55,6 +56,87 @@ fn write_schema(dir: &Path, name: &str, vertices: &[(&str, &str)]) {
     });
     let path = dir.join(name);
     std::fs::write(&path, serde_json::to_string_pretty(&schema).unwrap()).unwrap();
+}
+
+fn write_atproto_project(dir: &Path, target_required: bool) {
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(
+        dir.join("panproto.toml"),
+        r#"[workspace]
+name = "lexicons"
+
+[[package]]
+name = "lexicons"
+path = "."
+protocol = "atproto"
+"#,
+    )
+    .unwrap();
+    let mut annotation = serde_json::json!({
+        "lexicon": 1,
+        "id": "pub.example.annotation",
+        "defs": {
+            "main": {
+                "type": "record",
+                "record": {
+                    "type": "object",
+                    "properties": {
+                        "target": {
+                            "type": "ref",
+                            "ref": "pub.example.defs#target"
+                        }
+                    }
+                }
+            }
+        }
+    });
+    if target_required {
+        annotation["defs"]["main"]["record"]["required"] = serde_json::json!(["target"]);
+    }
+    std::fs::write(
+        dir.join("annotation.json"),
+        serde_json::to_vec_pretty(&annotation).unwrap(),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("defs.json"),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "lexicon": 1,
+            "id": "pub.example.defs",
+            "defs": {
+                "target": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "string"}
+                    }
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+}
+
+fn staged_leaf_ids(
+    dir: &Path,
+) -> (
+    panproto_core::vcs::ObjectId,
+    HashMap<String, panproto_core::vcs::ObjectId>,
+) {
+    use panproto_core::vcs::{Repository, hash::hash_file_schema, walk_tree};
+
+    let repo = Repository::open(dir).unwrap();
+    let root = repo.read_index().unwrap().staged.unwrap().schema_id;
+    let mut leaves = HashMap::new();
+    walk_tree(repo.store(), &root, |path, file| {
+        leaves.insert(
+            path.to_string_lossy().into_owned(),
+            hash_file_schema(file).unwrap(),
+        );
+        Ok(())
+    })
+    .unwrap();
+    (root, leaves)
 }
 
 fn add_and_commit(dir: &Path, schema_file: &str, message: &str) {
@@ -197,6 +279,54 @@ fn cli_add_dry_run() {
         .current_dir(tmp.path())
         .assert()
         .failure();
+}
+
+#[test]
+fn cli_add_atproto_directory_stages_per_file_tree_and_reuses_unchanged_leaf() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_repo(tmp.path());
+    let project = tmp.path().join("lexicons");
+    write_atproto_project(&project, false);
+
+    schema_cmd()
+        .args(["add", "--skip-verify", "lexicons"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+    let (first_root, first_leaves) = staged_leaf_ids(tmp.path());
+    assert_eq!(
+        first_leaves.len(),
+        2,
+        "the manifest and directory must not be flattened into the schema"
+    );
+
+    schema_cmd()
+        .args(["commit", "-m", "first"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+    write_atproto_project(&project, true);
+
+    schema_cmd()
+        .args(["add", "--skip-verify", "lexicons"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+    let (second_root, second_leaves) = staged_leaf_ids(tmp.path());
+    assert_ne!(
+        first_root, second_root,
+        "changing one file must change the project root"
+    );
+    assert_eq!(
+        first_leaves.get("defs.json"),
+        second_leaves.get("defs.json"),
+        "the unchanged file must retain its object id"
+    );
+    assert_ne!(
+        first_leaves.get("annotation.json"),
+        second_leaves.get("annotation.json"),
+        "the changed file must receive a new object id"
+    );
 }
 
 #[test]
@@ -1809,7 +1939,6 @@ use panproto_core::inst;
 use panproto_core::mig;
 use panproto_core::schema::{Edge, Schema, Vertex};
 use smallvec::SmallVec;
-use std::collections::HashMap;
 
 /// Build a schema with named prop edges and all required adjacency indices.
 fn make_lift_schema(

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.65.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.65.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.65.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.65.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.65.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.65.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.65.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.65.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.65.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.64.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.65.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-py/src/lexicon.rs
+++ b/crates/panproto-py/src/lexicon.rs
@@ -260,8 +260,9 @@ pub fn parse_schema_bundle(protocol: &str, docs: &Bound<'_, PyAny>) -> PyResult<
 /// into one flat schema with no per-file identity).
 #[pyclass(name = "LexiconProject", module = "panproto._native")]
 pub struct PyLexiconProject {
-    files: Vec<(String, Arc<panproto_core::schema::Schema>)>,
-    cross: Vec<(String, Vec<panproto_core::schema::Edge>)>,
+    pub(crate) protocol: String,
+    pub(crate) files: Vec<(String, Arc<panproto_core::schema::Schema>)>,
+    pub(crate) cross: Vec<(String, Vec<panproto_core::schema::Edge>)>,
 }
 
 #[pymethods]
@@ -363,7 +364,11 @@ pub fn parse_schema_bundle_project(
         .map(|(p, edges)| (p.display().to_string(), edges))
         .collect();
 
-    Ok(PyLexiconProject { files, cross })
+    Ok(PyLexiconProject {
+        protocol: protocol.replace('_', "-"),
+        files,
+        cross,
+    })
 }
 
 /// Extract the GAT theory a schema instantiates.

--- a/crates/panproto-py/src/vcs.rs
+++ b/crates/panproto-py/src/vcs.rs
@@ -7,10 +7,12 @@
 //!   compatibility with earlier panproto-py releases.
 //! * [`PyRepository`] — the filesystem-backed `Repository` from
 //!   `panproto-vcs`. Wraps the full porcelain (`init`, `open`, `add`,
-//!   `commit`, `log`, `merge`, `cherry_pick`, `rebase`, `reset`, `amend`,
-//!   `gc`) plus the plumbing needed by external tooling (branches, tags,
-//!   blame, bisect, stash, status, data migration). Closes issue #56.
+//!   `add_project`, `commit`, `log`, `merge`, `cherry_pick`, `rebase`,
+//!   `reset`, `amend`, `gc`) plus the plumbing needed by external tooling
+//!   (branches, tags, blame, bisect, stash, status, data migration).
+//!   Closes issue #56.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -41,6 +43,7 @@ use panproto_core::vcs::{
 
 use crate::convert;
 use crate::error::VcsError;
+use crate::lexicon::PyLexiconProject;
 use crate::schema::PySchema;
 
 // ---------------------------------------------------------------------------
@@ -298,6 +301,48 @@ impl PyRepository {
         } else {
             self.inner.add(schema.inner.as_ref()).map_err(vcs_err)?
         };
+        convert::to_python(py, &index_to_value(&index))
+    }
+
+    /// Stage a per-file schema project for the next commit.
+    ///
+    /// ``project`` is produced by :func:`parse_schema_bundle_project`.
+    /// Each input document is stored as its own content-addressed leaf, so
+    /// unchanged files retain their object IDs across commits. Cross-file
+    /// references are assembled for migration derivation and validation,
+    /// while the index retains the per-file tree root.
+    #[pyo3(signature = (project, *, skip_verify=false))]
+    fn add_project(
+        &mut self,
+        py: Python<'_>,
+        project: &PyLexiconProject,
+        skip_verify: bool,
+    ) -> PyResult<Py<PyAny>> {
+        let files: HashMap<PathBuf, panproto_core::schema::Schema> = project
+            .files
+            .iter()
+            .map(|(path, schema)| (PathBuf::from(path), schema.as_ref().clone()))
+            .collect();
+        let protocols: HashMap<PathBuf, String> = files
+            .keys()
+            .map(|path| (path.clone(), project.protocol.clone()))
+            .collect();
+        let cross_file_edges: HashMap<PathBuf, Vec<Edge>> = project
+            .cross
+            .iter()
+            .map(|(path, edges)| (PathBuf::from(path), edges.clone()))
+            .collect();
+        let root_id = panproto_project::build_project_tree(
+            self.inner.store_mut(),
+            &files,
+            &protocols,
+            &cross_file_edges,
+        )
+        .map_err(vcs_err)?;
+        let index = self
+            .inner
+            .add_tree_with_options(root_id, &panproto_core::vcs::AddOptions { skip_verify })
+            .map_err(vcs_err)?;
         convert::to_python(py, &index_to_value(&index))
     }
 

--- a/crates/panproto-vcs/src/repo.rs
+++ b/crates/panproto-vcs/src/repo.rs
@@ -171,7 +171,49 @@ impl Repository {
         options: &AddOptions,
     ) -> Result<Index, VcsError> {
         let schema_id = crate::tree::store_schema_as_tree(&mut self.store, schema.clone())?;
+        self.stage_schema(schema_id, schema, options)
+    }
 
+    /// Stage an already-stored schema tree for the next commit.
+    ///
+    /// This is the project-aware counterpart to [`add`](Self::add): callers
+    /// first store a per-file tree (for instance with
+    /// `panproto_project::ProjectBuilder::build_tree`), then pass its root
+    /// object ID here. The tree is assembled for diffing and migration
+    /// validation, while the index retains the original per-file root.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `schema_id` does not name a valid schema tree, or
+    /// if the assembled schema cannot be staged.
+    pub fn add_tree(&mut self, schema_id: ObjectId) -> Result<Index, VcsError> {
+        self.add_tree_with_options(schema_id, &AddOptions::default())
+    }
+
+    /// Stage an already-stored schema tree for the next commit, with options.
+    ///
+    /// See [`add_tree`](Self::add_tree) and
+    /// [`add_with_options`](Self::add_with_options).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `schema_id` does not name a valid schema tree, or
+    /// if the assembled schema cannot be staged.
+    pub fn add_tree_with_options(
+        &mut self,
+        schema_id: ObjectId,
+        options: &AddOptions,
+    ) -> Result<Index, VcsError> {
+        let schema = self.load_schema(schema_id)?;
+        self.stage_schema(schema_id, &schema, options)
+    }
+
+    fn stage_schema(
+        &mut self,
+        schema_id: ObjectId,
+        schema: &Schema,
+        options: &AddOptions,
+    ) -> Result<Index, VcsError> {
         let (migration_id, auto_derived, validation, gat_diagnostics) = match store::resolve_head(
             &self.store,
         )? {
@@ -1106,6 +1148,57 @@ mod tests {
         // Verify HEAD points to the commit.
         let head = store::resolve_head(repo.store())?;
         assert_eq!(head, Some(commit_id));
+        Ok(())
+    }
+
+    #[test]
+    fn add_tree_retains_per_file_root_in_index_and_commit() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let dir = tempfile::tempdir()?;
+        let mut repo = Repository::init(dir.path())?;
+        let root_id = crate::tree::build_schema_tree(
+            repo.store_mut(),
+            vec![
+                (
+                    PathBuf::from("a.schema"),
+                    crate::object::FileSchemaObject {
+                        path: "a.schema".to_owned(),
+                        protocol: "test".to_owned(),
+                        schema: make_schema(&[("a", "object")]),
+                        cross_file_edges: Vec::new(),
+                    },
+                ),
+                (
+                    PathBuf::from("b.schema"),
+                    crate::object::FileSchemaObject {
+                        path: "b.schema".to_owned(),
+                        protocol: "test".to_owned(),
+                        schema: make_schema(&[("b", "string")]),
+                        cross_file_edges: Vec::new(),
+                    },
+                ),
+            ],
+        )?;
+
+        let index = repo.add_tree(root_id)?;
+        assert_eq!(
+            index.staged.as_ref().map(|staged| staged.schema_id),
+            Some(root_id),
+            "the index must retain the caller's per-file tree root"
+        );
+
+        let commit_id = repo.commit("per-file project", "test")?;
+        let Object::Commit(commit) = repo.store().get(&commit_id)? else {
+            panic!("commit id must resolve to a commit object");
+        };
+        assert_eq!(
+            commit.schema_id, root_id,
+            "the commit must point at the per-file tree root"
+        );
+        assert!(
+            matches!(repo.store().get(&commit.schema_id)?, Object::SchemaTree(_)),
+            "the committed schema must remain a tree"
+        );
         Ok(())
     }
 

--- a/tests/integration/tests/genericity_protocol_baseline.txt
+++ b/tests/integration/tests/genericity_protocol_baseline.txt
@@ -59,6 +59,7 @@ crates/panproto-py/src/schema.rs	atproto
 crates/panproto-py/src/schema.rs	bsky
 crates/panproto-py/src/schema.rs	lexicon
 crates/panproto-py/src/schema.rs	nsid
+crates/panproto-py/src/vcs.rs	lexicon
 crates/panproto-schema/src/builder.rs	atproto
 crates/panproto-schema/src/builder.rs	bsky
 crates/panproto-schema/src/builder.rs	nsid


### PR DESCRIPTION
## Summary

This PR closes the project-tree staging gap: VCS commits can retain per-file Merkle roots instead of flattening directories into monolithic schemas. It adds tree-aware repository staging APIs, routes CLI directory adds and ATProto bundles through them, exposes the same path in Python, and coordinates the `0.65.0` release version and changelog entry.

## Changes

- **VCS:** add `Repository::add_tree` and `add_tree_with_options`; assemble stored trees for migration derivation and validation while retaining the original root in the index and commit.
- **CLI:** make `schema add <dir>` stage `ProjectBuilder` trees; use the registered bundle-project parser for manifest-declared ATProto projects.
- **Python:** add `Repository.add_project(project, skip_verify=False)` and retain the originating protocol on `LexiconProject`.
- **Release:** bump every published version surface and grammar-package bound to `0.65.0`; add a dated changelog entry.
- **Tests:** verify that commits retain multi-file roots and that a changed ATProto file receives a new object ID while its unchanged sibling reuses the old ID.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (API, schema, or migration semantics)
- [ ] Build / CI / release infrastructure
- [ ] Documentation
- [ ] Refactor / internal cleanup
- [ ] Performance
- [ ] Security

## Affected surfaces

- [x] Rust crates (`crates/`) — `panproto-vcs`, `panproto-cli`, `panproto-py`; grammar-pack manifests receive the coordinated version bump
- [ ] WASM boundary (`crates/panproto-wasm`)
- [x] TypeScript SDK (`bindings/typescript`, `@panproto/core`) — coordinated version bump only
- [x] Python SDK (`bindings/python`, `crates/panproto-py`)
- [x] CLI (`crates/panproto-cli`)
- [ ] Book (`book/src/`)
- [ ] CI workflows (`.github/workflows/`)
- [ ] Internal only (no published-surface change)

## Linked issues

- Closes #243

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [ ] `wasm-pack build crates/panproto-wasm --target web --dev` (if WASM affected)
- [ ] `cd bindings/typescript && pnpm install && pnpm test && pnpm exec tsc --noEmit` (if TS SDK affected)
- [ ] `cd bindings/python && uv run pytest tests/ -x` (if Python SDK affected)
- [x] Local targeted Clippy: `cargo clippy -p panproto-vcs -p panproto-cli -p panproto-py --all-targets -- -D warnings`
- [x] Local Rust suites: `cargo nextest run -p panproto-vcs -p panproto-cli` — 481 passed
- [x] Local native Python module: `bindings/python/tests/test_native.py` — 128 passed
- [x] Version consistency: `.github/scripts/check_version_consistency.py --verbose`

## Documentation

- [ ] Updated relevant `README.md` files
- [ ] Updated `book/src/` chapters if user-facing concepts changed
- [ ] Updated CHANGELOG.md under `## [Unreleased]`
- [x] Updated docstrings / rustdoc on changed public items
- [ ] Documentation not required (pure refactor or internal only)

The changelog entry is dated under `0.65.0` because this PR includes the coordinated version bump.

## Release coordination

- [x] This PR bumps versions (`Cargo.toml`, `sdk/*/package.json`, etc.)
- [x] This PR adds, modifies, or removes a published-surface API and a CHANGELOG entry was added
- [ ] CI workflow change requires a one-time setup step on a third-party service (npm, crates.io, PyPI) — describe below

No one-time third-party setup is required. The `v0.65.0` release tag must be created from `main` only after this PR merges.

## Reviewer checklist

- [ ] Code compiles cleanly with `clippy -D warnings`
- [ ] Tests cover the change and existing tests still pass
- [ ] Public API changes are documented and CHANGELOG-noted
- [ ] No secrets, tokens, or PII in the diff
- [ ] No `unwrap` / `expect` / `panic!` introduced on the WASM or SDK boundary
- [ ] No `--no-verify`, `--allow-dirty`, or `unsafe` without explicit justification in this PR description
- [ ] Diff size is reviewable; if not, this PR is split into smaller pieces
