### PR TITLE
Expose view-only reconstruction to JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to panproto will be documented in this file.
 
+## [0.69.0] - 2026-07-30
+
+### Added
+
+- **View-only reconstruction is reachable from JavaScript** (`panproto-wasm`, `@panproto/core`): 0.68.0 added `put_without_complement` in the Rust core, which reconstructs a source from a stored view when the lens is an isomorphism, but the binding exposed only `putJson`, which needs the complement a prior in-process `getJson` produced. A record read back from storage has no such complement, so the capability added for exactly that case was unreachable from the SDK. `LensHandle.putJsonWithoutComplement(view, rootVertex)` closes that, backed by a new `put_json_without_complement` at the WASM boundary. Since availability is a property of the lens rather than of any record, `isIsomorphism()` and `isomorphismObstruction()` answer it once for every view a lens will produce: the latter returns the first failing condition (a dropped vertex, a dropped edge, or a non-injective value transform) or `null`, so a caller can branch statically instead of catching a throw. Closes #255.
+
 ## [0.68.0] - 2026-07-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "anyhow",
  "miette",
@@ -1924,7 +1924,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "ciborium",
  "git2",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "divan",
  "insta",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-dsl-eval"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "nickel-lang",
  "serde",
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "divan",
  "proptest",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "chumsky",
  "divan",
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "divan",
  "miette",
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "divan",
  "git2",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "git2",
  "miette",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "cc",
  "divan",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2144,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2198,7 +2198,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "divan",
  "insta",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "divan",
  "miette",
@@ -2313,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "divan",
  "memchr",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "divan",
  "miette",
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "blake3",
  "divan",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.68.0"
+version = "0.69.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -107,27 +107,27 @@ tree-sitter = "0.26"
 tree-sitter-tags = "0.26"
 
 # Workspace crates
-panproto-gat = { version = "0.68.0", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.68.0", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.68.0", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.68.0", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.68.0", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.68.0", path = "crates/panproto-lens" }
-panproto-dsl-eval = { version = "0.68.0", path = "crates/panproto-dsl-eval" }
-panproto-lens-dsl = { version = "0.68.0", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.68.0", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.68.0", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.68.0", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.68.0", path = "crates/panproto-core" }
-panproto-io = { version = "0.68.0", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.68.0", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.68.0", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.68.0", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.68.0", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.68.0", path = "crates/panproto-parse" }
-panproto-project = { version = "0.68.0", path = "crates/panproto-project" }
-panproto-git = { version = "0.68.0", path = "crates/panproto-git" }
-panproto-xrpc = { version = "0.68.0", path = "crates/panproto-xrpc" }
+panproto-gat = { version = "0.69.0", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.69.0", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.69.0", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.69.0", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.69.0", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.69.0", path = "crates/panproto-lens" }
+panproto-dsl-eval = { version = "0.69.0", path = "crates/panproto-dsl-eval" }
+panproto-lens-dsl = { version = "0.69.0", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.69.0", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.69.0", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.69.0", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.69.0", path = "crates/panproto-core" }
+panproto-io = { version = "0.69.0", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.69.0", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.69.0", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.69.0", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.69.0", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.69.0", path = "crates/panproto-parse" }
+panproto-project = { version = "0.69.0", path = "crates/panproto-project" }
+panproto-git = { version = "0.69.0", path = "crates/panproto-git" }
+panproto-xrpc = { version = "0.69.0", path = "crates/panproto-xrpc" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:             0.68.0
+version:             0.69.0
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/python-grammars-all/pyproject.toml
+++ b/bindings/python-grammars-all/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.68,<0.69",
+    "panproto>=0.69,<0.70",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-data/pyproject.toml
+++ b/bindings/python-grammars-data/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.68,<0.69",
+    "panproto>=0.69,<0.70",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-devops/pyproject.toml
+++ b/bindings/python-grammars-devops/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.68,<0.69",
+    "panproto>=0.69,<0.70",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-functional/pyproject.toml
+++ b/bindings/python-grammars-functional/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # companion via the entry point declared below; without panproto
     # installed there is no consumer for the grammars this package
     # ships.
-    "panproto>=0.68,<0.69",
+    "panproto>=0.69,<0.70",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-jvm/pyproject.toml
+++ b/bindings/python-grammars-jvm/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.68,<0.69",
+    "panproto>=0.69,<0.70",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-mobile/pyproject.toml
+++ b/bindings/python-grammars-mobile/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.68,<0.69",
+    "panproto>=0.69,<0.70",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-music/pyproject.toml
+++ b/bindings/python-grammars-music/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.68,<0.69",
+    "panproto>=0.69,<0.70",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-scripting/pyproject.toml
+++ b/bindings/python-grammars-scripting/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.68,<0.69",
+    "panproto>=0.69,<0.70",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-systems/pyproject.toml
+++ b/bindings/python-grammars-systems/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.68,<0.69",
+    "panproto>=0.69,<0.70",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/python-grammars-web/pyproject.toml
+++ b/bindings/python-grammars-web/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "panproto>=0.68,<0.69",
+    "panproto>=0.69,<0.70",
 ]
 
 [project.entry-points."panproto.grammars"]

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/bindings/typescript/src/lens.ts
+++ b/bindings/typescript/src/lens.ts
@@ -766,6 +766,81 @@ export class LensHandle implements Disposable {
   }
 
   /**
+   * Reconstruct a source record from a view alone, with no complement.
+   *
+   * {@link putJson} needs the complement a prior {@link getJson} produced,
+   * which a record read back from storage does not have. This is the path
+   * for that case, and it is available exactly when the lens is an
+   * isomorphism: a lens with complement decomposes its source as
+   * `S ≅ V × C`, so a view determines its source precisely when `C ≅ 1`.
+   * For any other lens distinct sources share the view and there is
+   * nothing to return, which is why this throws rather than guessing.
+   *
+   * Use {@link isomorphismObstruction} to decide in advance whether a
+   * given lens supports it; the condition is a property of the lens, not
+   * of a record, so one check answers for every view it produces.
+   *
+   * @param view - The stored view as a JS object or JSON string
+   * @param rootVertex - The target-schema vertex the view is rooted at
+   * @returns The reconstructed source record as a JS object
+   * @throws {@link WasmError} if the lens is not an isomorphism, naming
+   *         the condition that fails, or if parsing fails
+   */
+  putJsonWithoutComplement(view: unknown, rootVertex: string): unknown {
+    const viewBytes = typeof view === 'string'
+      ? new TextEncoder().encode(view)
+      : new TextEncoder().encode(JSON.stringify(view));
+
+    try {
+      const outputBytes = this.#wasm.exports.put_json_without_complement(
+        this.#handle.id,
+        viewBytes,
+        rootVertex,
+      );
+      return JSON.parse(new TextDecoder().decode(outputBytes));
+    } catch (error) {
+      throw new WasmError(
+        `put_json_without_complement failed: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+  }
+
+  /**
+   * Why this lens is not an isomorphism, or `null` when it is one.
+   *
+   * An isomorphism is a lens whose complement is terminal: every vertex
+   * survives, every edge survives up to renaming, and every value
+   * transform is invertible. Those are exactly the conditions under which
+   * {@link putJsonWithoutComplement} can reconstruct a source from a view,
+   * so this is the static test for whether that path is open.
+   *
+   * @returns The first failing condition, or `null` if the lens is an
+   *          isomorphism
+   * @throws {@link WasmError} if the WASM call fails
+   */
+  isomorphismObstruction(): string | null {
+    try {
+      const detail = this.#wasm.exports.lens_isomorphism_obstruction(this.#handle.id);
+      return detail === '' ? null : detail;
+    } catch (error) {
+      throw new WasmError(
+        `lens_isomorphism_obstruction failed: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+  }
+
+  /**
+   * Whether this lens is an isomorphism, so that a source is determined by
+   * its view alone. See {@link isomorphismObstruction} for the reason when
+   * it is not.
+   */
+  isIsomorphism(): boolean {
+    return this.isomorphismObstruction() === null;
+  }
+
+  /**
    * Check both GetPut and PutGet lens laws for an instance.
    *
    * @param instance - MessagePack-encoded instance data

--- a/bindings/typescript/src/types.ts
+++ b/bindings/typescript/src/types.ts
@@ -542,6 +542,8 @@ export interface WasmExports {
   lift_json(migration: number, json: Uint8Array, root_vertex: string): Uint8Array;
   get_json(migration: number, json: Uint8Array, root_vertex: string): Uint8Array;
   put_json(migration: number, view_json: Uint8Array, complement: Uint8Array, root_vertex: string): Uint8Array;
+  put_json_without_complement(migration: number, view_json: Uint8Array, root_vertex: string): Uint8Array;
+  lens_isomorphism_obstruction(migration: number): string;
   instance_element_count(instance: Uint8Array): number;
   check_lens_laws(migration: number, instance: Uint8Array): Uint8Array;
   check_get_put(migration: number, instance: Uint8Array): Uint8Array;

--- a/bindings/typescript/src/wasm.ts
+++ b/bindings/typescript/src/wasm.ts
@@ -83,6 +83,8 @@ export interface WasmGlueModule {
   lift_json: WasmExports['lift_json'];
   get_json: WasmExports['get_json'];
   put_json: WasmExports['put_json'];
+  put_json_without_complement: WasmExports['put_json_without_complement'];
+  lens_isomorphism_obstruction: WasmExports['lens_isomorphism_obstruction'];
   instance_element_count: WasmExports['instance_element_count'];
   auto_generate_protolens: WasmExports['auto_generate_protolens'];
   auto_generate_candidates: WasmExports['auto_generate_candidates'];
@@ -226,6 +228,8 @@ export async function loadWasm(input?: string | URL | WasmGlueModule): Promise<W
       lift_json: glue.lift_json,
       get_json: glue.get_json,
       put_json: glue.put_json,
+      put_json_without_complement: glue.put_json_without_complement,
+      lens_isomorphism_obstruction: glue.lens_isomorphism_obstruction,
       instance_element_count: glue.instance_element_count,
       auto_generate_protolens: glue.auto_generate_protolens,
       auto_generate_candidates: glue.auto_generate_candidates,

--- a/bindings/typescript/tests/real-wasm.test.ts
+++ b/bindings/typescript/tests/real-wasm.test.ts
@@ -490,6 +490,91 @@ describe('compileLensDocument', () => {
     proto[Symbol.dispose]();
   });
 
+  // A stored view has no in-process `getJson` behind it and so no
+  // complement. Reconstructing from it is possible exactly when the lens
+  // is an isomorphism, since a lens with complement decomposes its source
+  // as `S ≅ V × C` and a view determines its source only when `C ≅ 1`.
+  it('putJsonWithoutComplement reconstructs from a stored view', () => {
+    const proto = buildCustomProto();
+    const schema = buildCustomSchema(proto);
+
+    // The identity chain: nothing dropped, nothing transformed, so the
+    // complement is terminal.
+    const chain = pp.compileLensDocument(
+      { id: 'demo.identity', source: 'v1', target: 'v2', steps: [] },
+      'rec:body',
+    );
+    const lens = chain.instantiate(schema);
+
+    expect(lens.isIsomorphism()).toBe(true);
+    expect(lens.isomorphismObstruction()).toBeNull();
+
+    // No `getJson` first: this is a record as it would come back from
+    // storage.
+    const restored = lens.putJsonWithoutComplement(
+      { text: 'hello' },
+      'rec:body',
+    ) as Record<string, unknown>;
+    expect(restored.text).toBe('hello');
+
+    lens[Symbol.dispose]();
+    chain[Symbol.dispose]();
+    schema[Symbol.dispose]();
+    proto[Symbol.dispose]();
+  });
+
+  it('putJsonWithoutComplement refuses a lens that is not an isomorphism', () => {
+    const proto = buildCustomProto();
+    const schema = buildCustomSchema(proto);
+
+    // A computed field with no inverse is not injective, so distinct
+    // sources share a view and no reconstruction exists.
+    const chain = pp.compileLensDocument(
+      {
+        id: 'demo.lossy',
+        source: 'v1',
+        target: 'v2',
+        steps: [{ compute_field: { target: 'g', expr: '{ a = text }' } }],
+      },
+      'rec:body',
+    );
+    const lens = chain.instantiate(schema);
+
+    const obstruction = lens.isomorphismObstruction();
+    expect(obstruction).not.toBeNull();
+    expect(lens.isIsomorphism()).toBe(false);
+
+    // And the refusal carries the same reason rather than being opaque.
+    expect(() => lens.putJsonWithoutComplement({ text: 'hello' }, 'rec:body')).toThrow();
+
+    lens[Symbol.dispose]();
+    chain[Symbol.dispose]();
+    schema[Symbol.dispose]();
+    proto[Symbol.dispose]();
+  });
+
+  it('putJsonWithoutComplement agrees with putJson on an isomorphism', () => {
+    const proto = buildCustomProto();
+    const schema = buildCustomSchema(proto);
+    const chain = pp.compileLensDocument(
+      { id: 'demo.agree', source: 'v1', target: 'v2', steps: [] },
+      'rec:body',
+    );
+    const lens = chain.instantiate(schema);
+
+    const record = { text: 'hello' };
+    const { view, complement } = lens.getJson(record, 'rec:body');
+    const withComplement = lens.putJson(view, complement, 'rec:body');
+    const withoutComplement = lens.putJsonWithoutComplement(view, 'rec:body');
+
+    expect(withoutComplement).toEqual(withComplement);
+
+    lens[Symbol.dispose]();
+    chain[Symbol.dispose]();
+    schema[Symbol.dispose]();
+    proto[Symbol.dispose]();
+  });
+
   it('putJson restores the source record from a view and complement', () => {
     const proto = buildCustomProto();
     const schema = buildCustomSchema(proto);

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.68.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.68.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.68.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.68.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.68.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.68.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.68.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.68.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.68.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.68.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-wasm/src/api/schema.rs
+++ b/crates/panproto-wasm/src/api/schema.rs
@@ -739,6 +739,93 @@ pub fn put_json(
     })
 }
 
+/// Reconstruct a source record from a view alone, with no complement.
+///
+/// A lens with complement decomposes its source as `S ≅ V × C`, so a view
+/// determines its source exactly when `C ≅ 1`, which is to say exactly when
+/// the lens is an isomorphism. That is the case this covers, and it is the
+/// only case in which a section of the forward direction exists: otherwise
+/// distinct sources share the view and there is nothing to return.
+///
+/// This is the path for a *stored* view, which by definition has no
+/// in-process `get_json` behind it and so no complement to pass to
+/// [`put_json`]. Use [`lens_isomorphism_obstruction`] to decide in advance
+/// whether a given lens supports it.
+///
+/// # Errors
+///
+/// Returns `JsError` when the lens is not an isomorphism, naming which
+/// condition fails, or when parsing or serialization fails.
+#[wasm_bindgen]
+pub fn put_json_without_complement(
+    migration: u32,
+    view_json_bytes: &[u8],
+    root_vertex: &str,
+) -> Result<Vec<u8>, JsError> {
+    let view_json: serde_json::Value =
+        serde_json::from_slice(view_json_bytes).map_err(|e| WasmError::DeserializationFailed {
+            reason: e.to_string(),
+        })?;
+
+    let result = slab::with_resource(migration, |r| {
+        let (compiled, src_schema, tgt_schema) = extract_migration_owned(r)?;
+
+        let tgt_root = find_root(root_vertex, &tgt_schema)?;
+        let view_instance = inst::parse_json(&tgt_schema, &tgt_root, &view_json).map_err(|e| {
+            WasmError::ParseFailed {
+                reason: e.to_string(),
+            }
+        })?;
+
+        let lens_obj = lens::Lens {
+            compiled,
+            src_schema: src_schema.clone(),
+            tgt_schema,
+        };
+
+        let restored = lens::put_without_complement(&lens_obj, &view_instance).map_err(|e| {
+            WasmError::PutFailed {
+                reason: e.to_string(),
+            }
+        })?;
+
+        let out_json = inst::to_json(&src_schema, &restored);
+        Ok(out_json)
+    })?;
+
+    serde_json::to_vec(&result).map_err(|e| -> JsError {
+        WasmError::SerializationFailed {
+            reason: e.to_string(),
+        }
+        .into()
+    })
+}
+
+/// Why this lens is not an isomorphism, or an empty string when it is one.
+///
+/// A caller can use this to decide statically whether
+/// [`put_json_without_complement`] is available for a lens, rather than
+/// discovering it from a thrown error. The condition is a property of the
+/// lens rather than of any record, so one check answers for every view it
+/// will ever produce.
+///
+/// # Errors
+///
+/// Returns `JsError` if the handle is not a migration.
+#[wasm_bindgen]
+pub fn lens_isomorphism_obstruction(migration: u32) -> Result<String, JsError> {
+    let obstruction = slab::with_resource(migration, |r| {
+        let (compiled, src_schema, tgt_schema) = extract_migration_owned(r)?;
+        let lens_obj = lens::Lens {
+            compiled,
+            src_schema,
+            tgt_schema,
+        };
+        Ok(lens_obj.obstruction_to_isomorphism().unwrap_or_default())
+    })?;
+    Ok(obstruction)
+}
+
 /// Find a root vertex in the schema, preferring object-kind vertices.
 fn find_root(
     root_vertex: &str,


### PR DESCRIPTION
## Summary

0.68.0 added `put_without_complement` in `panproto-lens`: reconstruction of a source from a stored view alone, available exactly when the lens is an isomorphism. The binding was never wired, so `@panproto/core` still offered only `putJson`, which needs the complement a prior in-process `getJson` produced. A record read back from storage has no such complement, which means the capability added for precisely that use case was unreachable from the SDK. This wires it.

## Changes

**WASM boundary** — `crates/panproto-wasm/src/api/schema.rs`

- `put_json_without_complement(migration, view_json, root_vertex)`, mirroring `put_json` without the complement argument.
- `lens_isomorphism_obstruction(migration)`, returning the first failing condition or an empty string.

**TypeScript SDK** — `lens.ts`, `types.ts`, `wasm.ts`

- `LensHandle.putJsonWithoutComplement(view, rootVertex)`.
- `isomorphismObstruction(): string | null` and `isIsomorphism(): boolean`.

The issue lists the obstruction accessor as optional. It is included because the alternative is discovering unavailability by catching a throw, and the condition is static: a lens either admits view-only reconstruction or it does not, for every record it will ever see. Branching on that is more useful than handling an exception per call.

## Why the refusal is not a limitation

A lens with complement decomposes its source as `S ≅ V × C`, with `get` the isomorphism and `put` its inverse. Reconstruction from a view alone asks for `S ≅ V`, which holds exactly when `C ≅ 1`. For any other lens `get` is not injective: distinct sources share a view, the fibre over it has more than one point, and there is no section to return. The three conditions `isIsomorphism` checks (every vertex survives, every edge survives up to renaming, every value transform is invertible) are the three ways the complement acquires residue.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (API, schema, or migration semantics)
- [ ] Build / CI / release infrastructure
- [ ] Documentation
- [ ] Refactor / internal cleanup
- [ ] Performance
- [ ] Security

## Affected surfaces

- [ ] Rust crates (`crates/`) — list which:
- [x] WASM boundary (`crates/panproto-wasm`)
- [x] TypeScript SDK (`bindings/typescript`, `@panproto/core`)
- [ ] Python SDK (`bindings/python`, `crates/panproto-py`)
- [ ] CLI (`crates/panproto-cli`)
- [ ] Book (`book/src/`)
- [ ] CI workflows (`.github/workflows/`)
- [ ] Internal only (no published-surface change)

No `panproto-lens` source changed; the capability already existed there.

## Linked issues

- Closes #255

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` — 3349 passed, 3 skipped
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `wasm-pack build crates/panproto-wasm --target web` — **run this time**, unlike the preceding PRs in this series, because this one is the first to change WASM source. The exports were then verified present in the generated `panproto_wasm.d.ts` and `panproto_wasm.js` rather than inferred from the build exiting zero.
- [x] `cd bindings/typescript && pnpm test && pnpm exec tsc --noEmit` — 139 passed (136 before), typecheck clean
- [ ] `cd bindings/python && uv run pytest tests/ -x` — not run; the Python SDK is untouched and exposes no lens JSON surface
- [x] Manual: the three new tests run against the freshly built binary, confirmed individually rather than via the aggregate count

Three tests in `bindings/typescript/tests/real-wasm.test.ts`, all against the real WASM module:

- reconstruction from a stored view with no forward pass behind it
- refusal for a lens that is not an isomorphism, with the obstruction reported through `isomorphismObstruction` as well as the throw
- agreement with `putJson` where both apply, so the complement-free path is not a separate operation that merely happens to work

## Documentation

- [ ] Updated relevant `README.md` files
- [ ] Updated `book/src/` chapters if user-facing concepts changed
- [x] Updated CHANGELOG.md — under `## [0.69.0]`, since this PR carries the version bump
- [x] Updated docstrings / rustdoc on changed public items
- [ ] Documentation not required (pure refactor or internal only)

## Release coordination

- [x] This PR bumps versions — 0.68.0 → **0.69.0**. `check_version_consistency.py` passes.
- [x] This PR adds, modifies, or removes a published-surface API and a CHANGELOG entry was added
- [ ] CI workflow change requires a one-time setup step on a third-party service

No tag pushed.

## Note for the reviewer

`dist/` and `pkg/` are gitignored, so nothing built is committed here; the `TypeScript SDK` CI job runs `pnpm run build` (which includes `build:wasm`) before `pnpm test`, so it compiles the new exports from source rather than testing against a stale artifact. I checked that specifically, since the new tests would otherwise pass locally and fail in CI.

Unrelated to this change but worth filing separately: `panproto-c bindist` failed on the v0.68.0 tag because it polls for the cargo-dist release to exist and gave up while `Release` was still compiling binaries. A re-run fixed it, but it will recur whenever `Release` runs long, since the timeout depends on runner load rather than on anything in the repository.
