### PR TITLE
fix(panproto-inst): refuse a self-parent move and bound the ancestor walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to panproto will be documented in this file.
 
+## [0.69.1] - 2026-08-11
+
+### Fixed
+
+- **A tree edit can no longer make a node its own parent, and an ancestor walk always terminates** (`panproto-inst`): `apply_move_subtree` guards against cycles by asking whether the new parent is a descendant of the node being moved. `is_descendant` walks *up* from its candidate, so it starts at the candidate's parent and never considers the candidate itself; asked whether a node is a descendant of that same node, it answered no on any acyclic instance. The guard passed, the move wrote `parent_map[node] = node`, and the resulting self-loop was not merely wrong but unwalkable: `is_descendant` has no visited set and no bound, so every later ancestor traversal through that node ran forever. A `MoveSubtree` whose `node_id` equals its `new_parent` is now refused with `CycleDetected`, and the walk is bounded by the node count, since a `WInstance` is deserialized and reaches the engine from hosts across the FFI boundary, where a predicate that hangs on malformed input is worse than one that answers wrongly.
+
+  This surfaced as the `edit_laws::action_laws` property tests timing out in CI. They generate `MoveSubtree` edits over the instance's own node ids, so a self-parent move is one of the shapes they explore; the three of them share `arb_scenario`, which is why all three could hang. Nothing about the tests changed. What changed is that 0.69.0 added a runtime bound to the `ci` nextest profile, which turned a run that never finished into a failure, exactly as that bound intended. At 20000 cases the three tests now complete in under ten seconds. Closes #260.
+
 ## [0.69.0] - 2026-07-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "anyhow",
  "miette",
@@ -1924,7 +1924,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "ciborium",
  "git2",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "divan",
  "insta",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "divan",
  "panproto-check",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-dsl-eval"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "nickel-lang",
  "serde",
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "divan",
  "proptest",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "chumsky",
  "divan",
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "divan",
  "miette",
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "divan",
  "git2",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "git2",
  "miette",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "cc",
  "divan",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2144,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2198,7 +2198,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "divan",
  "insta",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "divan",
  "miette",
@@ -2313,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "divan",
  "memchr",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "blake3",
  "divan",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "blake3",
  "divan",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "divan",
  "miette",
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "blake3",
  "divan",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.69.0"
+version = "0.69.1"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -107,27 +107,27 @@ tree-sitter = "0.26"
 tree-sitter-tags = "0.26"
 
 # Workspace crates
-panproto-gat = { version = "0.69.0", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.69.0", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.69.0", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.69.0", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.69.0", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.69.0", path = "crates/panproto-lens" }
-panproto-dsl-eval = { version = "0.69.0", path = "crates/panproto-dsl-eval" }
-panproto-lens-dsl = { version = "0.69.0", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.69.0", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.69.0", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.69.0", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.69.0", path = "crates/panproto-core" }
-panproto-io = { version = "0.69.0", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.69.0", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.69.0", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.69.0", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.69.0", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.69.0", path = "crates/panproto-parse" }
-panproto-project = { version = "0.69.0", path = "crates/panproto-project" }
-panproto-git = { version = "0.69.0", path = "crates/panproto-git" }
-panproto-xrpc = { version = "0.69.0", path = "crates/panproto-xrpc" }
+panproto-gat = { version = "0.69.1", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.69.1", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.69.1", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.69.1", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.69.1", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.69.1", path = "crates/panproto-lens" }
+panproto-dsl-eval = { version = "0.69.1", path = "crates/panproto-dsl-eval" }
+panproto-lens-dsl = { version = "0.69.1", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.69.1", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.69.1", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.69.1", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.69.1", path = "crates/panproto-core" }
+panproto-io = { version = "0.69.1", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.69.1", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.69.1", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.69.1", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.69.1", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.69.1", path = "crates/panproto-parse" }
+panproto-project = { version = "0.69.1", path = "crates/panproto-project" }
+panproto-git = { version = "0.69.1", path = "crates/panproto-git" }
+panproto-xrpc = { version = "0.69.1", path = "crates/panproto-xrpc" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:             0.69.0
+version:             0.69.1
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.69.0",
+  "version": "0.69.1",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.69.1", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.69.1", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.69.1", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.69.1", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.69.1", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.69.1", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.69.1", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.69.1", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.69.1", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.69.0", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.69.1", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-inst/src/tree_edit.rs
+++ b/crates/panproto-inst/src/tree_edit.rs
@@ -424,8 +424,17 @@ fn apply_move_subtree(
     if !instance.nodes.contains_key(&new_parent) {
         return Err(EditError::ParentNotFound(new_parent));
     }
-    // Prevent cycles: new_parent must not be a descendant of node_id.
-    if is_descendant(instance, new_parent, node_id) {
+    // Prevent cycles: a node cannot be its own parent, and `new_parent`
+    // must not be a descendant of `node_id`.
+    //
+    // The self-parent case needs its own test. `is_descendant` walks up
+    // from `new_parent`, so it starts at the node's parent and never
+    // considers the node itself; with `node_id == new_parent` it reports
+    // false on an acyclic instance and the move then writes
+    // `parent_map[node_id] = node_id`. That self-loop is not merely
+    // wrong, it is unwalkable: every later ancestor traversal through
+    // the node spins forever.
+    if node_id == new_parent || is_descendant(instance, new_parent, node_id) {
         return Err(EditError::CycleDetected {
             node_id,
             new_parent,
@@ -454,9 +463,20 @@ fn apply_move_subtree(
 }
 
 /// Check if `candidate` is a descendant of `ancestor` in the instance tree.
+///
+/// The walk is bounded by the node count, so a `parent_map` that already
+/// carries a cycle answers `false` rather than looping. Nothing in this
+/// module can now introduce such a cycle, but the map is part of a
+/// deserialized `WInstance` and reaches here from hosts across the FFI
+/// boundary; a predicate that hangs on malformed input is a denial of
+/// service rather than a wrong answer, and a chain longer than every
+/// node in the instance has necessarily revisited one.
 fn is_descendant(instance: &WInstance, candidate: u32, ancestor: u32) -> bool {
     let mut current = candidate;
-    while let Some(&parent) = instance.parent_map.get(&current) {
+    for _ in 0..instance.parent_map.len() {
+        let Some(&parent) = instance.parent_map.get(&current) else {
+            return false;
+        };
         if parent == ancestor {
             return true;
         }
@@ -518,6 +538,8 @@ mod tests {
     use crate::metadata::Node;
     use crate::value::Value;
     use crate::wtype::WInstance;
+
+    use super::{EditError, is_descendant};
 
     use super::TreeEdit;
 
@@ -630,6 +652,57 @@ mod tests {
 
         assert_eq!(inst.parent_map[&2], 1);
         assert!(inst.children_map[&1].contains(&2));
+    }
+
+    #[test]
+    fn move_subtree_refuses_to_make_a_node_its_own_parent() {
+        // `is_descendant` walks up from `new_parent`, so it never
+        // considers the node itself and reported no cycle here. The move
+        // then wrote `parent_map[1] = 1`, and every later ancestor walk
+        // through node 1 ran forever.
+        let mut nodes = HashMap::new();
+        nodes.insert(0, Node::new(0, "root"));
+        nodes.insert(1, Node::new(1, "a"));
+        let arcs = vec![(0, 1, sample_edge("root", "a"))];
+        let mut inst = WInstance::new(nodes, arcs, vec![], 0, Name::from("root"));
+
+        let edit = TreeEdit::MoveSubtree {
+            node_id: 1,
+            new_parent: 1,
+            edge: sample_edge("a", "a"),
+        };
+
+        assert!(matches!(
+            edit.apply(&mut inst),
+            Err(EditError::CycleDetected {
+                node_id: 1,
+                new_parent: 1
+            })
+        ));
+        assert_eq!(inst.parent_map[&1], 0, "the instance is left as it was");
+    }
+
+    #[test]
+    fn ancestor_walk_terminates_on_a_cyclic_parent_map() {
+        // A `WInstance` can arrive already carrying a cycle: it is
+        // deserialized, and hosts hand one across the FFI boundary. The
+        // walk is bounded by the node count so such an instance answers
+        // rather than hanging.
+        let mut nodes = HashMap::new();
+        nodes.insert(0, Node::new(0, "root"));
+        nodes.insert(1, Node::new(1, "a"));
+        nodes.insert(2, Node::new(2, "b"));
+        let arcs = vec![
+            (0, 1, sample_edge("root", "a")),
+            (1, 2, sample_edge("a", "b")),
+        ];
+        let mut inst = WInstance::new(nodes, arcs, vec![], 0, Name::from("root"));
+
+        // Close the chain by hand: 1 -> 2 -> 1.
+        inst.parent_map.insert(1, 2);
+
+        assert!(!is_descendant(&inst, 2, 99));
+        assert!(is_descendant(&inst, 2, 1));
     }
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,24 @@ ignore = [
     # nickel-lang-core used only at Nickel evaluation time (not in hot paths).
     # No security impact; will be resolved when nickel-lang updates.
     "RUSTSEC-2024-0436",
+    # bitmaps is unmaintained (RUSTSEC-2026-0247, repository archived
+    # 2026-05-03). It arrives through nickel-lang -> nickel-lang-vector ->
+    # imbl-sized-chunks and is reached only at Nickel evaluation time. The
+    # advisory records no vulnerability, only that the crate is no longer
+    # maintained.
+    #
+    # Upgrading does not remove it and cannot: nickel-lang 2.2.0 still
+    # resolves nickel-lang-vector 0.2.0 -> imbl-sized-chunks 0.1.3 ->
+    # bitmaps 3.2.1, so the newer release carries the same dependency.
+    # Upgrading also fails on a second count, since nickel-lang 2.2.0 pulls
+    # malachite 0.9.2 (Rust 1.90) and nickel-lang-core 0.18.0 (Rust 1.89)
+    # against this workspace's declared rust-version of 1.85, which the
+    # `Tests (1.85.0)` matrix job enforces.
+    #
+    # The alternatives the advisory names (fixedbitset, bitvec) are a choice
+    # for imbl to make, not something a downstream consumer can force, so
+    # this is ignored until imbl or nickel moves off it.
+    "RUSTSEC-2026-0247",
     # quick-xml 0.37 denial-of-service advisories in namespace and duplicate-
     # attribute handling. panproto-io parses XML through the non-namespace
     # `quick_xml::Reader`, and RUSTSEC-2026-0195 explicitly states that a


### PR DESCRIPTION
## Summary

`apply_move_subtree` could make a node its own parent, and the resulting self-loop hung every later ancestor traversal. This surfaced as the `edit_laws::action_laws` property tests timing out in CI, which fails intermittently on unrelated PRs.

## Changes

- **`MoveSubtree` with `node_id == new_parent` is refused** with `CycleDetected`. The cycle guard asks `is_descendant(instance, new_parent, node_id)`, and `is_descendant` walks *up* from its candidate, so it starts at the candidate's parent and never considers the candidate itself. Asked whether a node is a descendant of that same node it answered no on any acyclic instance, the guard passed, and the move wrote `parent_map[node] = node`.
- **The ancestor walk is bounded by the node count.** The self-loop was not merely wrong but unwalkable: `is_descendant` had no visited set and no bound. Nothing in the module can introduce a cycle now, but a `WInstance` is deserialized and reaches the engine from hosts across the C ABI, and a predicate that hangs on malformed input is a denial of service rather than a wrong answer. A chain longer than every node in the instance has necessarily revisited one.
- Two regression tests: the self-parent move is refused and leaves the instance unchanged; the walk terminates on a deliberately cyclic `parent_map`.

## Why this surfaced now

Nothing in `edit_laws.rs` or `edit_lens.rs` changed; that file was last touched in `b775ec63`. What changed is that #254 added a runtime bound to the `ci` nextest profile:

```toml
slow-timeout = { period = "60s", terminate-after = 10, grace-period = "5s" }
```

Its comment says exactly what it was for: an unbounded test reads as slow rather than broken. Before that bound, hitting this input meant repeated `SLOW` lines and a long run; after it, the same input is a hard failure. `main` has had one CI run since the bound landed and drew a lucky seed. #259 drew unlucky ones twice, on two different tests.

The three tests generate `MoveSubtree` edits over the instance's own node ids, so a self-parent move is among the shapes they explore, and all three share `arb_scenario`, which is why all three could hang.

## Type of change

- [x] Bug fix (non-breaking)

## Affected surfaces

- [x] Rust crates (`crates/`) — `panproto-inst`
- [ ] Internal only (no published-surface change)

## Linked issues

- Closes #260

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run -p panproto-inst -p panproto-lens -p panproto-mig -p panproto-vcs --profile ci` — 1216 passed
- [x] The reproduction from #260, before and after:

```
before:  3 tests run: 0 passed, 3 failed   (SIGTERM at 400s)
after:   3 tests run: 3 passed             (9.5s at 20,000 cases)
```

A full `cargo nextest run --workspace` did not fit on the machine I verified from (a full workspace build needs roughly 28 GB and the disk had about 20 GB free), so the workspace run is left to CI, which clears space before building. Everything the change can reach is covered by the scoped run above.

## Documentation

- [x] Updated CHANGELOG.md
- [x] Updated docstrings on changed items

## Release coordination

- [x] This PR bumps versions (0.69.0 to 0.69.1)

A patch bump: a bug fix with no API change. #259 sits on 0.70.0 and will take this through a merge from `main`.
