### PR TITLE
fix(ci): verify the Swift pin from where a consumer sits

### DIFF
--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -145,12 +145,20 @@ jobs:
           PY
           git diff --stat bindings/swift/Package.swift
       - name: Verify a clean consumer build resolves against the pin
-        # No staged library, no environment overrides: exactly what a
-        # downstream package sees when it adds this one as a dependency.
+        # No staged library and no environment overrides, and crucially a
+        # location with no panproto workspace above it. The manifest picks
+        # the binary target only when it cannot see `crates/panproto-c` two
+        # directories up, because a source checkout must build its own C ABI
+        # rather than fall back to a released artifact whose header predates
+        # it. Building in place leaves that crate a grandparent away, which
+        # selects the system library and links nothing, so the pin has to be
+        # exercised from a copy that sits where a dependent package would.
         run: |
           set -euo pipefail
-          rm -rf bindings/swift/.panproto-c
-          cd bindings/swift && swift build
+          consumer="$(mktemp -d)/swift"
+          cp -R bindings/swift "$consumer"
+          rm -rf "$consumer/.panproto-c" "$consumer/.build"
+          cd "$consumer" && swift build
       - name: Lint the rewritten manifest
         # This job commits to main, so whatever it writes has to satisfy
         # the same gate a pull request does. Neither pinned value fits the


### PR DESCRIPTION
## Summary

The v0.72.0 release's `Publish Swift SDK` workflow failed, and because `Pin the release XCFramework` is the gate job, `Mirror the package` and `Publish DocC` were both skipped. **v0.72.0 never reached the Swift package mirror**, and `main`'s pin still names v0.71.0.

The artifact and the pin are both fine. The verification step was wrong.

## What happened

The step rewrites the release pin, then builds the package to prove the pin resolves — in place, inside the checkout:

```yaml
rm -rf bindings/swift/.panproto-c
cd bindings/swift && swift build
```

Its comment claims this is "exactly what a downstream package sees". It isn't. The manifest selects the binary target only when it cannot see `crates/panproto-c/Cargo.toml` two directories up, because a source checkout must build its own C ABI rather than link a released artifact whose header predates its sources. In the runner's checkout that crate *is* two directories up, so the manifest correctly chose `.systemLibrary`, nothing had staged a library, and the link failed:

```
ld: warning: Could not find or use auto-linked library 'panproto_c'
  "_pp_last_error_take", referenced from: ...
ld: symbol(s) not found for architecture arm64
```

## The fix

Copy the package somewhere with no workspace above it, and build there — which is what a dependent package actually resolves.

## Verification

Reproduced the consumer path locally against the real v0.72.0 artifact: copied `bindings/swift` outside the workspace, pinned it to the v0.72.0 URL and checksum, and built.

```
[95/97] Linking atproto-post-migration
Build complete! (60.42s)
```

It downloads the XCFramework and links `libpanproto_c.a`. So the pin resolves; only the location was wrong.

Also audited every other `swift build` in CI. All of them either run `bootstrap/dev-link.sh` first (`ci.yml:353`, `publish-swift.yml:193,387`) or pass `PANPROTO_SWIFT_XCFRAMEWORK` (`build-panproto-c-bindist.yml:266`), and both paths bypass this branch correctly. This step was the only one affected.

## Follow-up not in this PR

The pin job spent ~54 minutes polling for the XCFramework, succeeding on attempt 162 of 180. It works, but the margin is thin: a slower bindist run would exhaust the budget and fail for an unrelated reason. Worth either raising the cap or making the dependency explicit rather than a poll.

## Type of change

- [x] Build / CI / release infrastructure

## Affected surfaces

- [x] CI workflows (`.github/workflows/`)
- [x] Swift SDK (`bindings/swift`) — release path only, no source change
