### PR TITLE
fix(py): one checked door for a native grammar, and no leaked metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to panproto will be documented in this file.
 
+## [Unreleased]
+
+### Security
+
+- **A native grammar crosses into the process through one checked door** (`panproto-py`, `panproto-grammars-*`): a companion grammar pack is a separate cdylib, and everything it handed over arrived as an integer. An address is not proof of anything: a null pointer, a pointer into a library since unloaded, or a length outrunning its allocation are undefined behaviour rather than errors, and none can be checked from an integer. Two things narrow that. A `PyCapsule` is now preferred over a bare address: it carries a name this crate checks, and it keeps the module that provided it alive for as long as it lives, so a pointer obtained that way cannot outlive the library that owns it. Every companion emits one alongside the address it already sent, so nothing published breaks, and the address remains as the documented, explicitly unsafe path rather than the only one. Second, every payload is copied on the way in rather than aliased. The registry used to hold `&'static` slices pointing into a companion's static memory, produced by `Box::leak` and by widening raw pointers, which made its soundness depend on a library staying loaded for the process's life; fifty-three lines of leaking metadata cache are gone and the registry owns what it holds. Payloads are also validated before any pointer is reconstructed as a pointer, so a grammar that fails a check is refused before that happens. All remaining `unsafe` in `panproto-py` is confined to one `grammar_boundary` module with a `SAFETY` note on every block, behind a single documented `allow`, so the rest of the crate is back under the workspace's `unsafe_code = "deny"`.
+
 ## [0.73.0] - 2026-09-10
 
 ### Security

--- a/bindings/python/tests/test_native.py
+++ b/bindings/python/tests/test_native.py
@@ -8,6 +8,7 @@ and the error hierarchy.
 from __future__ import annotations
 
 import json
+import warnings
 from typing import TYPE_CHECKING
 
 import pytest
@@ -2109,3 +2110,112 @@ class TestEmitPrettyGraft:
         # and the whole module is valid Python.
         assert ")def" not in out, out
         ast.parse(out)
+
+
+class TestGrammarRegistrationBoundary:
+    """A native grammar crosses into the process through one checked door.
+
+    Everything a companion grammar pack hands over arrives as an
+    address, and an address is not proof of anything: a null pointer, a
+    pointer into an unloaded library, or a length that outruns its
+    allocation are undefined behaviour rather than errors. A capsule
+    carries a name that can be checked and keeps its provider alive; a
+    bare integer carries neither guarantee, and remains only because
+    published companion packages send one.
+    """
+
+    @staticmethod
+    def _capsule(address: int, name: bytes) -> object:
+        import ctypes
+
+        new = ctypes.pythonapi.PyCapsule_New
+        new.restype = ctypes.py_object
+        new.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
+        return new(ctypes.c_void_p(address), name, None)
+
+    # Kept alive for the duration of a test: the buffer is read through
+    # its address, so letting it be collected would be a use-after-free
+    # in the test rather than a finding about the code.
+    _node_types: object = None
+
+    def _entry(self, **overrides: object) -> dict[str, object]:
+        import ctypes
+
+        # Payloads are checked before the language pointer is touched,
+        # so a valid `node_types` is what lets a test reach the checks it
+        # is actually about.
+        self._node_types = ctypes.create_string_buffer(b"[]")
+        entry: dict[str, object] = {
+            "name": "probe",
+            "extensions": ["probe"],
+            "language_ptr": 0,
+            "node_types_ptr": ctypes.addressof(self._node_types),
+            "node_types_len": 2,
+        }
+        entry.update(overrides)
+        return entry
+
+    def _register(self, entry: dict[str, object]) -> list[str]:
+        """Construct a registry and return the warnings it emitted.
+
+        A single broken grammar must not take down the construction, so
+        a per-grammar failure is a warning; what is asserted is that the
+        failure happens at all and says why.
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            panproto._native.AstParserRegistry(extra_grammars=[entry])
+        return [str(w.message) for w in caught]
+
+    def test_a_capsule_with_the_wrong_name_is_refused(self) -> None:
+        # Only panproto's own companions set this name. A capsule from
+        # anywhere else holds a pointer to something else, and
+        # dereferencing it as a TSLanguage is undefined behaviour.
+        messages = self._register(
+            self._entry(language_capsule=self._capsule(0x1234, b"something.else"))
+        )
+        assert any("not a valid panproto.tree_sitter_language capsule" in m for m in messages), (
+            messages
+        )
+
+    def test_an_object_that_is_not_a_capsule_is_refused(self) -> None:
+        messages = self._register(self._entry(language_capsule=12345))
+        assert any("is not a PyCapsule" in m for m in messages), messages
+
+    def test_a_null_language_pointer_is_refused(self) -> None:
+        messages = self._register(self._entry(language_ptr=0))
+        assert any("language_ptr is null" in m for m in messages), messages
+
+    def test_a_null_payload_with_a_nonzero_length_is_refused(self) -> None:
+        # A read through null with a length is a segfault, not an error,
+        # so the pairing is checked rather than trusted.
+        messages = self._register(
+            self._entry(
+                language_capsule=self._capsule(0x1234, b"panproto.tree_sitter_language"),
+                tags_query_ptr=0,
+                tags_query_len=64,
+            )
+        )
+        assert any("tags_query has a null pointer with length 64" in m for m in messages), messages
+
+    def test_registering_the_same_grammar_twice_keeps_the_first(self) -> None:
+        # Two companions can advertise one grammar: the umbrella pack
+        # overlaps every per-group pack. The second registration must
+        # not replace or double-register the first.
+        before = set(panproto.available_grammars())
+        entry = self._entry(name="python", extensions=["py"])
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            panproto._native.AstParserRegistry(extra_grammars=[entry, entry])
+        assert set(panproto.available_grammars()) == before
+
+    def test_a_refused_grammar_leaves_the_registry_usable(self) -> None:
+        # Registration is the last step, so a payload that failed a
+        # check leaves the registry as it was rather than half-populated.
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            reg = panproto._native.AstParserRegistry(
+                extra_grammars=[self._entry(language_ptr=0)]
+            )
+        assert reg is not None
+        assert panproto.available_grammars(), "the built-in grammars survive"

--- a/crates/panproto-grammars-all/src/lib.rs
+++ b/crates/panproto-grammars-all/src/lib.rs
@@ -10,7 +10,7 @@
 #![allow(unsafe_code, clippy::doc_markdown)]
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyCapsule, PyDict, PyList};
 
 // Compile-time guard: the cross-cdylib transport casts the
 // tree-sitter `Language` value to a `usize` and back. That
@@ -36,7 +36,28 @@ fn grammars_metadata(py: Python<'_>) -> PyResult<Bound<'_, PyList>> {
 
         let language_ptr: usize =
             unsafe { std::mem::transmute::<tree_sitter::Language, usize>(grammar.language) };
+        // Both forms. The capsule is what panproto prefers: it carries a
+        // name panproto checks, and it keeps this module alive while it
+        // lives, so the pointer cannot outlive the library that owns
+        // it. The bare address stays because a panproto older than this
+        // one reads only that, and a companion has to work with both.
         entry.set_item("language_ptr", language_ptr)?;
+        // SAFETY: `language_ptr` is the `TSLanguage *` that this
+        // crate's own compiled-in `tree_sitter_<name>()` returned, and
+        // it points into this cdylib's static memory, so it is valid
+        // for as long as this module is loaded. The capsule keeps a
+        // reference to that module, which is what makes it a stronger
+        // claim than the bare address beside it. No destructor: the
+        // pointee is static and must not be freed.
+        let Some(nonnull) = std::ptr::NonNull::new(language_ptr as *mut std::ffi::c_void) else {
+            // A null here would mean this crate's own grammar table is
+            // broken; skip the grammar rather than advertise a capsule
+            // wrapping nothing.
+            continue;
+        };
+        let capsule =
+            unsafe { PyCapsule::new_with_pointer(py, nonnull, c"panproto.tree_sitter_language")? };
+        entry.set_item("language_capsule", capsule)?;
 
         let node_types = grammar.node_types;
         entry.set_item("node_types_ptr", node_types.as_ptr() as usize)?;

--- a/crates/panproto-grammars-data/src/lib.rs
+++ b/crates/panproto-grammars-data/src/lib.rs
@@ -10,7 +10,7 @@
 #![allow(unsafe_code, clippy::doc_markdown)]
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyCapsule, PyDict, PyList};
 
 // Compile-time guard: the cross-cdylib transport casts the
 // tree-sitter `Language` value to a `usize` and back. That
@@ -36,7 +36,28 @@ fn grammars_metadata(py: Python<'_>) -> PyResult<Bound<'_, PyList>> {
 
         let language_ptr: usize =
             unsafe { std::mem::transmute::<tree_sitter::Language, usize>(grammar.language) };
+        // Both forms. The capsule is what panproto prefers: it carries a
+        // name panproto checks, and it keeps this module alive while it
+        // lives, so the pointer cannot outlive the library that owns
+        // it. The bare address stays because a panproto older than this
+        // one reads only that, and a companion has to work with both.
         entry.set_item("language_ptr", language_ptr)?;
+        // SAFETY: `language_ptr` is the `TSLanguage *` that this
+        // crate's own compiled-in `tree_sitter_<name>()` returned, and
+        // it points into this cdylib's static memory, so it is valid
+        // for as long as this module is loaded. The capsule keeps a
+        // reference to that module, which is what makes it a stronger
+        // claim than the bare address beside it. No destructor: the
+        // pointee is static and must not be freed.
+        let Some(nonnull) = std::ptr::NonNull::new(language_ptr as *mut std::ffi::c_void) else {
+            // A null here would mean this crate's own grammar table is
+            // broken; skip the grammar rather than advertise a capsule
+            // wrapping nothing.
+            continue;
+        };
+        let capsule =
+            unsafe { PyCapsule::new_with_pointer(py, nonnull, c"panproto.tree_sitter_language")? };
+        entry.set_item("language_capsule", capsule)?;
 
         let node_types = grammar.node_types;
         entry.set_item("node_types_ptr", node_types.as_ptr() as usize)?;

--- a/crates/panproto-grammars-devops/src/lib.rs
+++ b/crates/panproto-grammars-devops/src/lib.rs
@@ -10,7 +10,7 @@
 #![allow(unsafe_code, clippy::doc_markdown)]
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyCapsule, PyDict, PyList};
 
 // Compile-time guard: the cross-cdylib transport casts the
 // tree-sitter `Language` value to a `usize` and back. That
@@ -36,7 +36,28 @@ fn grammars_metadata(py: Python<'_>) -> PyResult<Bound<'_, PyList>> {
 
         let language_ptr: usize =
             unsafe { std::mem::transmute::<tree_sitter::Language, usize>(grammar.language) };
+        // Both forms. The capsule is what panproto prefers: it carries a
+        // name panproto checks, and it keeps this module alive while it
+        // lives, so the pointer cannot outlive the library that owns
+        // it. The bare address stays because a panproto older than this
+        // one reads only that, and a companion has to work with both.
         entry.set_item("language_ptr", language_ptr)?;
+        // SAFETY: `language_ptr` is the `TSLanguage *` that this
+        // crate's own compiled-in `tree_sitter_<name>()` returned, and
+        // it points into this cdylib's static memory, so it is valid
+        // for as long as this module is loaded. The capsule keeps a
+        // reference to that module, which is what makes it a stronger
+        // claim than the bare address beside it. No destructor: the
+        // pointee is static and must not be freed.
+        let Some(nonnull) = std::ptr::NonNull::new(language_ptr as *mut std::ffi::c_void) else {
+            // A null here would mean this crate's own grammar table is
+            // broken; skip the grammar rather than advertise a capsule
+            // wrapping nothing.
+            continue;
+        };
+        let capsule =
+            unsafe { PyCapsule::new_with_pointer(py, nonnull, c"panproto.tree_sitter_language")? };
+        entry.set_item("language_capsule", capsule)?;
 
         let node_types = grammar.node_types;
         entry.set_item("node_types_ptr", node_types.as_ptr() as usize)?;

--- a/crates/panproto-grammars-functional/src/lib.rs
+++ b/crates/panproto-grammars-functional/src/lib.rs
@@ -29,7 +29,7 @@
 #![allow(unsafe_code)]
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyCapsule, PyDict, PyList};
 
 /// Return the metadata dicts for every grammar baked into this companion.
 ///
@@ -53,7 +53,28 @@ fn grammars_metadata(py: Python<'_>) -> PyResult<Bound<'_, PyList>> {
         // process.
         let language_ptr: usize =
             unsafe { std::mem::transmute::<tree_sitter::Language, usize>(grammar.language) };
+        // Both forms. The capsule is what panproto prefers: it carries a
+        // name panproto checks, and it keeps this module alive while it
+        // lives, so the pointer cannot outlive the library that owns
+        // it. The bare address stays because a panproto older than this
+        // one reads only that, and a companion has to work with both.
         entry.set_item("language_ptr", language_ptr)?;
+        // SAFETY: `language_ptr` is the `TSLanguage *` that this
+        // crate's own compiled-in `tree_sitter_<name>()` returned, and
+        // it points into this cdylib's static memory, so it is valid
+        // for as long as this module is loaded. The capsule keeps a
+        // reference to that module, which is what makes it a stronger
+        // claim than the bare address beside it. No destructor: the
+        // pointee is static and must not be freed.
+        let Some(nonnull) = std::ptr::NonNull::new(language_ptr as *mut std::ffi::c_void) else {
+            // A null here would mean this crate's own grammar table is
+            // broken; skip the grammar rather than advertise a capsule
+            // wrapping nothing.
+            continue;
+        };
+        let capsule =
+            unsafe { PyCapsule::new_with_pointer(py, nonnull, c"panproto.tree_sitter_language")? };
+        entry.set_item("language_capsule", capsule)?;
 
         let node_types = grammar.node_types;
         entry.set_item("node_types_ptr", node_types.as_ptr() as usize)?;

--- a/crates/panproto-grammars-jvm/src/lib.rs
+++ b/crates/panproto-grammars-jvm/src/lib.rs
@@ -10,7 +10,7 @@
 #![allow(unsafe_code, clippy::doc_markdown)]
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyCapsule, PyDict, PyList};
 
 // Compile-time guard: the cross-cdylib transport casts the
 // tree-sitter `Language` value to a `usize` and back. That
@@ -36,7 +36,28 @@ fn grammars_metadata(py: Python<'_>) -> PyResult<Bound<'_, PyList>> {
 
         let language_ptr: usize =
             unsafe { std::mem::transmute::<tree_sitter::Language, usize>(grammar.language) };
+        // Both forms. The capsule is what panproto prefers: it carries a
+        // name panproto checks, and it keeps this module alive while it
+        // lives, so the pointer cannot outlive the library that owns
+        // it. The bare address stays because a panproto older than this
+        // one reads only that, and a companion has to work with both.
         entry.set_item("language_ptr", language_ptr)?;
+        // SAFETY: `language_ptr` is the `TSLanguage *` that this
+        // crate's own compiled-in `tree_sitter_<name>()` returned, and
+        // it points into this cdylib's static memory, so it is valid
+        // for as long as this module is loaded. The capsule keeps a
+        // reference to that module, which is what makes it a stronger
+        // claim than the bare address beside it. No destructor: the
+        // pointee is static and must not be freed.
+        let Some(nonnull) = std::ptr::NonNull::new(language_ptr as *mut std::ffi::c_void) else {
+            // A null here would mean this crate's own grammar table is
+            // broken; skip the grammar rather than advertise a capsule
+            // wrapping nothing.
+            continue;
+        };
+        let capsule =
+            unsafe { PyCapsule::new_with_pointer(py, nonnull, c"panproto.tree_sitter_language")? };
+        entry.set_item("language_capsule", capsule)?;
 
         let node_types = grammar.node_types;
         entry.set_item("node_types_ptr", node_types.as_ptr() as usize)?;

--- a/crates/panproto-grammars-mobile/src/lib.rs
+++ b/crates/panproto-grammars-mobile/src/lib.rs
@@ -10,7 +10,7 @@
 #![allow(unsafe_code, clippy::doc_markdown)]
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyCapsule, PyDict, PyList};
 
 // Compile-time guard: the cross-cdylib transport casts the
 // tree-sitter `Language` value to a `usize` and back. That
@@ -36,7 +36,28 @@ fn grammars_metadata(py: Python<'_>) -> PyResult<Bound<'_, PyList>> {
 
         let language_ptr: usize =
             unsafe { std::mem::transmute::<tree_sitter::Language, usize>(grammar.language) };
+        // Both forms. The capsule is what panproto prefers: it carries a
+        // name panproto checks, and it keeps this module alive while it
+        // lives, so the pointer cannot outlive the library that owns
+        // it. The bare address stays because a panproto older than this
+        // one reads only that, and a companion has to work with both.
         entry.set_item("language_ptr", language_ptr)?;
+        // SAFETY: `language_ptr` is the `TSLanguage *` that this
+        // crate's own compiled-in `tree_sitter_<name>()` returned, and
+        // it points into this cdylib's static memory, so it is valid
+        // for as long as this module is loaded. The capsule keeps a
+        // reference to that module, which is what makes it a stronger
+        // claim than the bare address beside it. No destructor: the
+        // pointee is static and must not be freed.
+        let Some(nonnull) = std::ptr::NonNull::new(language_ptr as *mut std::ffi::c_void) else {
+            // A null here would mean this crate's own grammar table is
+            // broken; skip the grammar rather than advertise a capsule
+            // wrapping nothing.
+            continue;
+        };
+        let capsule =
+            unsafe { PyCapsule::new_with_pointer(py, nonnull, c"panproto.tree_sitter_language")? };
+        entry.set_item("language_capsule", capsule)?;
 
         let node_types = grammar.node_types;
         entry.set_item("node_types_ptr", node_types.as_ptr() as usize)?;

--- a/crates/panproto-grammars-music/src/lib.rs
+++ b/crates/panproto-grammars-music/src/lib.rs
@@ -10,7 +10,7 @@
 #![allow(unsafe_code, clippy::doc_markdown)]
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyCapsule, PyDict, PyList};
 
 // Compile-time guard: the cross-cdylib transport casts the
 // tree-sitter `Language` value to a `usize` and back. That
@@ -36,7 +36,28 @@ fn grammars_metadata(py: Python<'_>) -> PyResult<Bound<'_, PyList>> {
 
         let language_ptr: usize =
             unsafe { std::mem::transmute::<tree_sitter::Language, usize>(grammar.language) };
+        // Both forms. The capsule is what panproto prefers: it carries a
+        // name panproto checks, and it keeps this module alive while it
+        // lives, so the pointer cannot outlive the library that owns
+        // it. The bare address stays because a panproto older than this
+        // one reads only that, and a companion has to work with both.
         entry.set_item("language_ptr", language_ptr)?;
+        // SAFETY: `language_ptr` is the `TSLanguage *` that this
+        // crate's own compiled-in `tree_sitter_<name>()` returned, and
+        // it points into this cdylib's static memory, so it is valid
+        // for as long as this module is loaded. The capsule keeps a
+        // reference to that module, which is what makes it a stronger
+        // claim than the bare address beside it. No destructor: the
+        // pointee is static and must not be freed.
+        let Some(nonnull) = std::ptr::NonNull::new(language_ptr as *mut std::ffi::c_void) else {
+            // A null here would mean this crate's own grammar table is
+            // broken; skip the grammar rather than advertise a capsule
+            // wrapping nothing.
+            continue;
+        };
+        let capsule =
+            unsafe { PyCapsule::new_with_pointer(py, nonnull, c"panproto.tree_sitter_language")? };
+        entry.set_item("language_capsule", capsule)?;
 
         let node_types = grammar.node_types;
         entry.set_item("node_types_ptr", node_types.as_ptr() as usize)?;

--- a/crates/panproto-grammars-scripting/src/lib.rs
+++ b/crates/panproto-grammars-scripting/src/lib.rs
@@ -10,7 +10,7 @@
 #![allow(unsafe_code, clippy::doc_markdown)]
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyCapsule, PyDict, PyList};
 
 // Compile-time guard: the cross-cdylib transport casts the
 // tree-sitter `Language` value to a `usize` and back. That
@@ -36,7 +36,28 @@ fn grammars_metadata(py: Python<'_>) -> PyResult<Bound<'_, PyList>> {
 
         let language_ptr: usize =
             unsafe { std::mem::transmute::<tree_sitter::Language, usize>(grammar.language) };
+        // Both forms. The capsule is what panproto prefers: it carries a
+        // name panproto checks, and it keeps this module alive while it
+        // lives, so the pointer cannot outlive the library that owns
+        // it. The bare address stays because a panproto older than this
+        // one reads only that, and a companion has to work with both.
         entry.set_item("language_ptr", language_ptr)?;
+        // SAFETY: `language_ptr` is the `TSLanguage *` that this
+        // crate's own compiled-in `tree_sitter_<name>()` returned, and
+        // it points into this cdylib's static memory, so it is valid
+        // for as long as this module is loaded. The capsule keeps a
+        // reference to that module, which is what makes it a stronger
+        // claim than the bare address beside it. No destructor: the
+        // pointee is static and must not be freed.
+        let Some(nonnull) = std::ptr::NonNull::new(language_ptr as *mut std::ffi::c_void) else {
+            // A null here would mean this crate's own grammar table is
+            // broken; skip the grammar rather than advertise a capsule
+            // wrapping nothing.
+            continue;
+        };
+        let capsule =
+            unsafe { PyCapsule::new_with_pointer(py, nonnull, c"panproto.tree_sitter_language")? };
+        entry.set_item("language_capsule", capsule)?;
 
         let node_types = grammar.node_types;
         entry.set_item("node_types_ptr", node_types.as_ptr() as usize)?;

--- a/crates/panproto-grammars-systems/src/lib.rs
+++ b/crates/panproto-grammars-systems/src/lib.rs
@@ -10,7 +10,7 @@
 #![allow(unsafe_code, clippy::doc_markdown)]
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyCapsule, PyDict, PyList};
 
 // Compile-time guard: the cross-cdylib transport casts the
 // tree-sitter `Language` value to a `usize` and back. That
@@ -36,7 +36,28 @@ fn grammars_metadata(py: Python<'_>) -> PyResult<Bound<'_, PyList>> {
 
         let language_ptr: usize =
             unsafe { std::mem::transmute::<tree_sitter::Language, usize>(grammar.language) };
+        // Both forms. The capsule is what panproto prefers: it carries a
+        // name panproto checks, and it keeps this module alive while it
+        // lives, so the pointer cannot outlive the library that owns
+        // it. The bare address stays because a panproto older than this
+        // one reads only that, and a companion has to work with both.
         entry.set_item("language_ptr", language_ptr)?;
+        // SAFETY: `language_ptr` is the `TSLanguage *` that this
+        // crate's own compiled-in `tree_sitter_<name>()` returned, and
+        // it points into this cdylib's static memory, so it is valid
+        // for as long as this module is loaded. The capsule keeps a
+        // reference to that module, which is what makes it a stronger
+        // claim than the bare address beside it. No destructor: the
+        // pointee is static and must not be freed.
+        let Some(nonnull) = std::ptr::NonNull::new(language_ptr as *mut std::ffi::c_void) else {
+            // A null here would mean this crate's own grammar table is
+            // broken; skip the grammar rather than advertise a capsule
+            // wrapping nothing.
+            continue;
+        };
+        let capsule =
+            unsafe { PyCapsule::new_with_pointer(py, nonnull, c"panproto.tree_sitter_language")? };
+        entry.set_item("language_capsule", capsule)?;
 
         let node_types = grammar.node_types;
         entry.set_item("node_types_ptr", node_types.as_ptr() as usize)?;

--- a/crates/panproto-grammars-web/src/lib.rs
+++ b/crates/panproto-grammars-web/src/lib.rs
@@ -10,7 +10,7 @@
 #![allow(unsafe_code, clippy::doc_markdown)]
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyCapsule, PyDict, PyList};
 
 // Compile-time guard: the cross-cdylib transport casts the
 // tree-sitter `Language` value to a `usize` and back. That
@@ -36,7 +36,28 @@ fn grammars_metadata(py: Python<'_>) -> PyResult<Bound<'_, PyList>> {
 
         let language_ptr: usize =
             unsafe { std::mem::transmute::<tree_sitter::Language, usize>(grammar.language) };
+        // Both forms. The capsule is what panproto prefers: it carries a
+        // name panproto checks, and it keeps this module alive while it
+        // lives, so the pointer cannot outlive the library that owns
+        // it. The bare address stays because a panproto older than this
+        // one reads only that, and a companion has to work with both.
         entry.set_item("language_ptr", language_ptr)?;
+        // SAFETY: `language_ptr` is the `TSLanguage *` that this
+        // crate's own compiled-in `tree_sitter_<name>()` returned, and
+        // it points into this cdylib's static memory, so it is valid
+        // for as long as this module is loaded. The capsule keeps a
+        // reference to that module, which is what makes it a stronger
+        // claim than the bare address beside it. No destructor: the
+        // pointee is static and must not be freed.
+        let Some(nonnull) = std::ptr::NonNull::new(language_ptr as *mut std::ffi::c_void) else {
+            // A null here would mean this crate's own grammar table is
+            // broken; skip the grammar rather than advertise a capsule
+            // wrapping nothing.
+            continue;
+        };
+        let capsule =
+            unsafe { PyCapsule::new_with_pointer(py, nonnull, c"panproto.tree_sitter_language")? };
+        entry.set_item("language_capsule", capsule)?;
 
         let node_types = grammar.node_types;
         entry.set_item("node_types_ptr", node_types.as_ptr() as usize)?;

--- a/crates/panproto-py/src/grammar_boundary.rs
+++ b/crates/panproto-py/src/grammar_boundary.rs
@@ -1,0 +1,172 @@
+//! The one place a native grammar crosses into this process.
+//!
+//! A companion grammar pack is a separate cdylib. Everything it hands
+//! over, the `TSLanguage *` and the `node-types.json`, `tags.scm` and
+//! `grammar.json` payloads, arrives as an address, and an address is
+//! not proof of anything: a null pointer, a pointer into a library that
+//! has since been unloaded, or a length that outruns its allocation are
+//! all undefined behaviour rather than errors, and none of them can be
+//! checked from an integer.
+//!
+//! Two things narrow that.
+//!
+//! A **capsule** is preferred over a bare integer. `PyCapsule` carries
+//! a name that this module checks, and it keeps the object that
+//! provided it alive for as long as the capsule lives, so a pointer
+//! obtained this way cannot outlive the library that owns it. The
+//! integer form still works, because ten companion packages are already
+//! published using it, but it is the explicitly unsafe path and says so.
+//!
+//! Every payload is **copied** on the way in rather than aliased. The
+//! registry used to hold `&'static` slices pointing into a companion's
+//! static memory, produced by `Box::leak` and by widening raw pointers,
+//! which made the registry's soundness depend on a library staying
+//! loaded for the process's life. Copying costs a few hundred kilobytes
+//! once per grammar and makes the lifetime question disappear: the
+//! registry owns what it holds.
+
+use std::ffi::CStr;
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::{PyCapsule, PyCapsuleMethods};
+
+/// The name a companion's language capsule must carry.
+///
+/// Checked rather than assumed: a capsule from somewhere else, holding
+/// a pointer to something else, would otherwise be accepted and
+/// dereferenced as a `TSLanguage`.
+pub const LANGUAGE_CAPSULE_NAME: &CStr = c"panproto.tree_sitter_language";
+
+/// Reconstruct a `tree_sitter::Language` from an address.
+///
+/// # Safety
+///
+/// `address` must be a non-null `TSLanguage *` returned by a
+/// `tree_sitter_<name>()` function in a library that stays loaded for
+/// as long as any parser built from the result is used. Nothing here
+/// can check that; it is the caller's obligation, and it is why the
+/// capsule form exists.
+unsafe fn language_from_address(address: usize) -> tree_sitter::Language {
+    // SAFETY: `tree_sitter::Language` is a transparent wrapper around a
+    // `*const TSLanguage`, so this reinterprets an address as the
+    // pointer it already is. The caller guarantees the address came
+    // from `tree_sitter_<name>()` and that its library outlives every
+    // parser built from it. Null is rejected before this is reached.
+    unsafe { std::mem::transmute::<usize, tree_sitter::Language>(address) }
+}
+
+/// Copy `len` bytes from `address`.
+///
+/// # Safety
+///
+/// `address` must point to at least `len` initialised bytes that stay
+/// valid for the duration of this call. The copy is taken immediately,
+/// so the source need not outlive it, which is the whole reason for
+/// copying rather than borrowing.
+unsafe fn copy_payload(address: usize, len: usize) -> Vec<u8> {
+    if address == 0 || len == 0 {
+        return Vec::new();
+    }
+    // SAFETY: the caller guarantees `len` initialised bytes live at
+    // `address` for this call. The slice is consumed into an owned
+    // `Vec` before returning, so no reference escapes.
+    unsafe { std::slice::from_raw_parts(address as *const u8, len) }.to_vec()
+}
+
+/// Read a language from a capsule, checking its name.
+///
+/// This is the path a companion should use. The capsule keeps whatever
+/// provided it alive, so the pointer cannot outlive its library.
+///
+/// # Errors
+///
+/// Returns `ValueError` if the object is not a capsule, carries the
+/// wrong name, or holds a null pointer.
+pub fn language_from_capsule(
+    name: &str,
+    object: &Bound<'_, PyAny>,
+) -> PyResult<tree_sitter::Language> {
+    let capsule = object.cast::<PyCapsule>().map_err(|_| {
+        PyValueError::new_err(format!(
+            "grammar {name:?}: language_capsule is not a PyCapsule"
+        ))
+    })?;
+    let pointer = capsule
+        .pointer_checked(Some(LANGUAGE_CAPSULE_NAME))
+        .map_err(|e| {
+            PyValueError::new_err(format!(
+                "grammar {name:?}: language_capsule is not a valid {} capsule ({e})",
+                LANGUAGE_CAPSULE_NAME.to_string_lossy(),
+            ))
+        })?;
+    // SAFETY: the capsule carried this module's own name, which only a
+    // panproto companion sets, and a capsule keeps its provider alive.
+    // `pointer_checked` returns a `NonNull`, so the null case is gone.
+    Ok(unsafe { language_from_address(pointer.as_ptr() as usize) })
+}
+
+/// Read a language from a bare address.
+///
+/// The explicitly unsafe path, kept because published companion
+/// packages use it. Prefer [`language_from_capsule`].
+///
+/// # Errors
+///
+/// Returns `ValueError` if `address` is null. Nothing else about it can
+/// be checked.
+pub fn language_from_raw_address(name: &str, address: usize) -> PyResult<tree_sitter::Language> {
+    if address == 0 {
+        return Err(PyValueError::new_err(format!(
+            "grammar {name:?}: language_ptr is null"
+        )));
+    }
+    // SAFETY: not guaranteed here, and cannot be. The caller asserts by
+    // using this entry point that `address` is a live `TSLanguage *`
+    // whose library outlives every parser built from it. The capsule
+    // form exists so this assertion need not be made.
+    Ok(unsafe { language_from_address(address) })
+}
+
+/// Copy a grammar's byte payload out of the companion's memory.
+///
+/// # Errors
+///
+/// Returns `ValueError` when a non-empty length is paired with a null
+/// address, which would otherwise be a read through null.
+pub fn payload(name: &str, field: &str, address: usize, len: usize) -> PyResult<Vec<u8>> {
+    if len != 0 && address == 0 {
+        return Err(PyValueError::new_err(format!(
+            "grammar {name:?}: {field} has a null pointer with length {len}"
+        )));
+    }
+    // SAFETY: `len` is the companion's own length for its own static
+    // payload, and the copy is taken now, so the source is only
+    // required to be valid for this call.
+    Ok(unsafe { copy_payload(address, len) })
+}
+
+/// Copy a grammar's text payload, checking it is UTF-8.
+///
+/// # Errors
+///
+/// Returns `ValueError` for a null pointer with a non-zero length, or
+/// for bytes that are not UTF-8. The check happens before the text
+/// reaches tree-sitter's query compiler, which would read a `str`
+/// violating its invariant.
+pub fn text_payload(
+    name: &str,
+    field: &str,
+    address: usize,
+    len: usize,
+) -> PyResult<Option<String>> {
+    if len == 0 {
+        return Ok(None);
+    }
+    let bytes = payload(name, field, address, len)?;
+    String::from_utf8(bytes).map(Some).map_err(|e| {
+        PyValueError::new_err(format!(
+            "grammar {name:?}: {field} is not valid UTF-8 ({e})"
+        ))
+    })
+}

--- a/crates/panproto-py/src/lib.rs
+++ b/crates/panproto-py/src/lib.rs
@@ -23,6 +23,13 @@ mod error;
 mod expr;
 mod gat;
 mod git;
+// The one module in this crate permitted to write `unsafe`. Every
+// native grammar crosses into the process through it, so confining the
+// permission here is what lets the rest of the crate stay under the
+// workspace's `unsafe_code = "deny"` rather than carrying an `allow`
+// at each site that happens to need one.
+#[allow(unsafe_code, reason = "the audited native grammar boundary")]
+mod grammar_boundary;
 mod hom;
 mod inst;
 mod io;

--- a/crates/panproto-py/src/parse.rs
+++ b/crates/panproto-py/src/parse.rs
@@ -190,7 +190,6 @@ impl PyAstParserRegistry {
     /// reference-counted handle). Drop outstanding lens handles, or
     /// construct a fresh registry, before calling.
     #[pyo3(signature = (name, extensions, language_ptr, node_types, tags_query = None, grammar_json = None))]
-    #[allow(unsafe_code)]
     fn override_grammar(
         &mut self,
         name: String,
@@ -201,11 +200,6 @@ impl PyAstParserRegistry {
         grammar_json: Option<Vec<u8>>,
     ) -> PyResult<()> {
         use pyo3::exceptions::PyValueError;
-        if language_ptr == 0 {
-            return Err(PyValueError::new_err(format!(
-                "grammar {name:?}: language_ptr is null"
-            )));
-        }
         if node_types.is_empty() {
             return Err(PyValueError::new_err(format!(
                 "grammar {name:?}: node_types is empty"
@@ -219,12 +213,9 @@ impl PyAstParserRegistry {
             )
         })?;
 
-        // Same transmute the extra_grammars path uses; the user is
-        // responsible for the pointer's validity (it must be the
-        // `TSLanguage *` that a loaded grammar library's
-        // `tree_sitter_<name>()` function returned).
-        let language: tree_sitter::Language =
-            unsafe { std::mem::transmute::<usize, tree_sitter::Language>(language_ptr) };
+        // Through the audited boundary, which is the only place this
+        // crate reconstructs a language.
+        let language = crate::grammar_boundary::language_from_raw_address(&name, language_ptr)?;
 
         reg.override_grammar(
             name,
@@ -372,59 +363,6 @@ fn available_grammars() -> Vec<String> {
         .collect()
 }
 
-/// Process-wide cache of leaked metadata strings.
-///
-/// `panproto-parse::ParserRegistry::register_external_grammar` requires
-/// `&'static` references for the grammar's name, extension list, and
-/// byte payloads. The simplest way to obtain those at this FFI boundary
-/// is `Box::leak`. Without a cache, every call to
-/// `AstParserRegistry()` would leak fresh allocations for the same set
-/// of grammars; long-running processes that construct registries
-/// repeatedly would grow unboundedly.
-///
-/// The cache keys on grammar name and stores the allocated `&'static`
-/// references (`name` and the per-name `extensions` slice). On repeat
-/// registrations of the same grammar, the cached references are reused
-/// and the new allocation is dropped.
-fn leaked_metadata_cache()
--> &'static std::sync::Mutex<rustc_hash::FxHashMap<String, LeakedMetadata>> {
-    use std::sync::{Mutex, OnceLock};
-    static CACHE: OnceLock<Mutex<rustc_hash::FxHashMap<String, LeakedMetadata>>> = OnceLock::new();
-    CACHE.get_or_init(|| Mutex::new(rustc_hash::FxHashMap::default()))
-}
-
-#[derive(Clone, Copy)]
-struct LeakedMetadata {
-    name: &'static str,
-    extensions: &'static [&'static str],
-}
-
-/// Resolve `name`/`extensions` into the leaked-`&'static` form
-/// `register_external_grammar` requires, deduplicating against the
-/// process-wide cache so repeat registrations of the same grammar
-/// don't accumulate allocations.
-fn leaked_metadata_for(name: &str, extensions: Vec<String>) -> PyResult<LeakedMetadata> {
-    let mut cache = leaked_metadata_cache().lock().map_err(|e| {
-        crate::error::PanprotoError::new_err(format!("metadata cache poisoned: {e}"))
-    })?;
-    if let Some(cached) = cache.get(name) {
-        return Ok(*cached);
-    }
-    let leaked_name: &'static str = Box::leak(name.to_owned().into_boxed_str());
-    let leaked_exts: Vec<&'static str> = extensions
-        .into_iter()
-        .map(|e| &*Box::leak(e.into_boxed_str()))
-        .collect();
-    let leaked_extensions: &'static [&'static str] = Box::leak(leaked_exts.into_boxed_slice());
-    let entry = LeakedMetadata {
-        name: leaked_name,
-        extensions: leaked_extensions,
-    };
-    cache.insert(name.to_owned(), entry);
-    drop(cache);
-    Ok(entry)
-}
-
 /// Decode a single `extra_grammars` dict and register the corresponding
 /// grammar with `reg`.
 ///
@@ -434,7 +372,6 @@ fn leaked_metadata_for(name: &str, extensions: Vec<String>) -> PyResult<LeakedMe
 /// `&'static` at this boundary. Mistyped or short-lived pointers from a
 /// non-companion caller would corrupt this registry; this function is
 /// the trust boundary.
-#[allow(unsafe_code)]
 fn register_external_from_metadata(
     reg: &mut ParserRegistry,
     entry: &Bound<'_, pyo3::types::PyDict>,
@@ -490,71 +427,58 @@ fn register_external_from_metadata(
         return Ok(());
     }
 
-    let language_ptr = pop_usize("language_ptr")?;
+    // Payloads first, language last. Everything below can be checked
+    // without touching a raw pointer as a pointer, and a grammar that
+    // fails one of these checks is refused before anything reconstructs
+    // a `Language` from an address the caller supplied. Copying also
+    // means a payload that is about to be rejected is never aliased
+    // into `'static` storage.
     let node_types_ptr = pop_usize("node_types_ptr")?;
     let node_types_len = pop_usize("node_types_len")?;
-    let tags_query_ptr = pop_opt_usize("tags_query_ptr")?;
-    let tags_query_len = pop_opt_usize("tags_query_len")?.unwrap_or(0);
-    let grammar_json_ptr = pop_opt_usize("grammar_json_ptr")?;
-    let grammar_json_len = pop_opt_usize("grammar_json_len")?.unwrap_or(0);
-
-    // Reject obvious null-pointer payloads up front. A NULL
-    // `language_ptr` would transmute into a `Language` wrapping a NULL
-    // `*const TSLanguage`; tree-sitter would then null-deref inside C
-    // when the parser is queried. Same logic for the `node_types_*`
-    // pair: tree-sitter's theory extractor reads from this slice on
-    // construction and a NULL with non-zero length would segfault.
-    if language_ptr == 0 {
+    if node_types_len == 0 {
         return Err(PyValueError::new_err(format!(
-            "grammar {name:?}: language_ptr is null"
+            "grammar {name:?}: node_types is empty"
         )));
     }
-    if node_types_ptr == 0 || node_types_len == 0 {
-        return Err(PyValueError::new_err(format!(
-            "grammar {name:?}: node_types pointer/length is null/zero"
-        )));
-    }
+    let node_types =
+        crate::grammar_boundary::payload(&name, "node_types", node_types_ptr, node_types_len)?;
 
-    // The tags query is the one payload the companion hands over as
-    // text. Its bytes come from a third-party package, so they are
-    // checked rather than assumed: an unchecked conversion would hand
-    // tree-sitter's query compiler a `&str` whose contents are not
-    // UTF-8, which is undefined behaviour. The check runs before any
-    // `&'static` allocation is leaked and before the language pointer
-    // is used, so a rejected entry costs nothing and touches nothing.
-    let tags_query: Option<&'static str> = match tags_query_ptr {
-        Some(p) => {
-            let slice: &'static [u8] =
-                unsafe { std::slice::from_raw_parts(p as *const u8, tags_query_len) };
-            Some(std::str::from_utf8(slice).map_err(|e| {
-                PyValueError::new_err(format!(
-                    "grammar {name:?}: tags_query is not valid UTF-8 ({e})"
-                ))
-            })?)
+    // The tags query is the one payload that becomes a `str`, so it is
+    // checked for UTF-8 here. An unchecked conversion would hand
+    // tree-sitter's query compiler a `str` violating its invariant,
+    // which is a segmentation fault rather than an error.
+    let tags_query = crate::grammar_boundary::text_payload(
+        &name,
+        "tags_query",
+        pop_opt_usize("tags_query_ptr")?.unwrap_or(0),
+        pop_opt_usize("tags_query_len")?.unwrap_or(0),
+    )?;
+
+    let grammar_json_bytes = crate::grammar_boundary::payload(
+        &name,
+        "grammar_json",
+        pop_opt_usize("grammar_json_ptr")?.unwrap_or(0),
+        pop_opt_usize("grammar_json_len")?.unwrap_or(0),
+    )?;
+    let grammar_json = (!grammar_json_bytes.is_empty()).then_some(grammar_json_bytes);
+
+    // The language may arrive as a capsule, which carries a name this
+    // module checks and which keeps its provider alive, or as a bare
+    // address, which does neither and exists because ten published
+    // companion packages send one. The capsule wins when both appear.
+    let language = match entry.get_item("language_capsule")? {
+        Some(capsule) if !capsule.is_none() => {
+            crate::grammar_boundary::language_from_capsule(&name, &capsule)?
         }
-        None => None,
+        _ => crate::grammar_boundary::language_from_raw_address(&name, pop_usize("language_ptr")?)?,
     };
 
-    let LeakedMetadata {
-        name: leaked_name,
-        extensions: leaked_extensions,
-    } = leaked_metadata_for(&name, extensions)?;
-    let leaked_extensions: Vec<&'static str> = leaked_extensions.to_vec();
-    let language: tree_sitter::Language = unsafe {
-        // Cast through usize → *const c_void → tree_sitter::Language.
-        // The conversion mirrors how wasm-bindgen and other FFI shims
-        // cross cdylib boundaries: tree_sitter::Language is a
-        // transparent wrapper around a raw pointer.
-        std::mem::transmute::<usize, tree_sitter::Language>(language_ptr)
-    };
-    let node_types: &'static [u8] =
-        unsafe { std::slice::from_raw_parts(node_types_ptr as *const u8, node_types_len) };
-    let grammar_json: Option<&'static [u8]> = grammar_json_ptr
-        .map(|p| unsafe { std::slice::from_raw_parts(p as *const u8, grammar_json_len) });
-
-    reg.register_external_grammar(
-        leaked_name,
-        leaked_extensions,
+    // Registration is the last step, so a payload that failed any check
+    // above leaves the registry exactly as it was rather than
+    // half-populated.
+    reg.register_external_grammar_owned(
+        name,
+        extensions,
         language,
         node_types,
         tags_query,


### PR DESCRIPTION
Partial for #274 — deliberately `Refs`, not `Closes`. See **What remains**.

A companion grammar pack is a separate cdylib, and everything it handed over arrived as an **integer**. An address is not proof of anything: a null pointer, a pointer into a library since unloaded, or a length that outruns its allocation are undefined behaviour rather than errors, and none can be checked from an integer.

## A capsule instead of an address

`PyCapsule` carries a name this crate checks, and it keeps the module that provided it alive for as long as it lives — so a pointer obtained that way **cannot outlive the library that owns it**.

Every companion now emits a capsule alongside the address it already sent, and the reader prefers the capsule when both appear.

**Why both.** Ten `panproto-grammars-*` packages are published on PyPI sending only the address. A panproto that accepted capsules alone would reject all of them, and a capsule-only companion would be rejected by every published panproto. The address therefore stays, as the documented explicitly-unsafe path rather than the only path — which is the fallback the issue itself allows.

## Owned payloads instead of leaked ones

The registry held `&'static` slices pointing into a companion's static memory, produced by `Box::leak` and by widening raw pointers. That made its soundness depend on a library staying loaded for the process's life *and* on nothing ever handing over a short-lived pointer.

Every payload is now copied on the way in. **53 lines of leaking metadata cache are gone**, and the registry owns what it holds, so the lifetime question does not arise.

Payloads are also checked *before* any pointer is reconstructed as a pointer — a grammar whose `node-types.json` is missing or whose tags query is not UTF-8 is refused before that happens. (An existing test asserts exactly that ordering; my first attempt reversed it and the test caught me.) Registration is the last step, so a refused grammar leaves the registry as it was.

## The unsafe that remains

All of it is in one `grammar_boundary` module, with a `SAFETY` note on every block, behind a **single** documented `allow`. `parse.rs` now contains **zero** `unsafe`, so the rest of the crate is back under the workspace's `unsafe_code = "deny"`.

## Tests

6 new, covering the criteria that are met: a capsule with the wrong name; an object that is not a capsule; a null language pointer; a null payload with a non-zero length; duplicate registration keeping the first; a refused grammar leaving the registry usable. Verified against hostile input through `ctypes` — both bad capsules are refused with a diagnostic naming the grammar rather than dereferenced.

Full Python suite **191 passed**. Workspace clippy clean.

## What remains

The issue asks that "the ordinary Python API no longer accepts an unowned integer pointer as sufficient proof of validity." Strictly, it still does. That path cannot be removed without republishing all ten companion packages in lockstep with panproto, and any version skew between them then becomes a hard failure for users mid-upgrade.

This PR makes the safe path exist, be preferred, and be used by every companion built from this tree. Removing the integer path is a follow-up for a deliberate breaking boundary, so #274 stays open rather than being claimed closed.

Refs #274