### PR TITLE
docs(dsl-eval): give the crate a README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ All notable changes to panproto will be documented in this file.
 
 - **A release artifact is installed and exercised before it is published** (`.github/workflows/publish-npm.yml`, `python-wheels.yml`, `publish-crates.yml`, `build-panproto-c-bindist.yml`): CI tested the source workspace thoroughly and never tested what users install. The npm package is now packed, installed from the tarball into a directory with no path back to the repository, and made to parse a bundle through the real WASM, so a missing `.wasm` or an entry point that resolves only next to the repo fails before publication rather than on a user's first import. Each native Python wheel is installed with `--no-index` on its build host and made to run a real operation from outside the source tree; this binding has shipped that exact defect before, when the 0.42.0 wheel contained only the compiled extension with no `__init__.py` and every check passed. Crates are packaged and the packaged form built before anything publishes, restoring the verification `--no-verify` skips, and every packaged crate is checked to carry a licence. The C archives are unpacked, checked for a header and a library, and on natively runnable targets compiled and linked against by a small C program.
 
+### Documentation
+
+- **`panproto-dsl-eval` has a README** (`crates/panproto-dsl-eval/README.md`): it was the one publishable crate of twenty-five with neither a README file nor a `readme` key, so it rendered on crates.io as a bare title and a one-line description. The new README follows the layout the other crates use, and covers the part that is not evident from the API: a caller embeds its Nickel contract library with `include_str!` and passes it as a `BundledContract`, which is staged at `<tmpdir>/panproto/<file_name>` with that directory placed first on the import path, so a document resolves it by writing `import "panproto/<file_name>"`.
+
+
 ## [0.73.0] - 2026-09-10
 
 ### Security

--- a/crates/panproto-dsl-eval/README.md
+++ b/crates/panproto-dsl-eval/README.md
@@ -1,0 +1,67 @@
+# panproto-dsl-eval
+
+[![crates.io](https://img.shields.io/crates/v/panproto-dsl-eval.svg)](https://crates.io/crates/panproto-dsl-eval)
+[![docs.rs](https://docs.rs/panproto-dsl-eval/badge.svg)](https://docs.rs/panproto-dsl-eval)
+[![MIT](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
+
+Shared Nickel, JSON, and YAML evaluation for panproto's declarative DSLs.
+
+## Source formats
+
+[`panproto-lens-dsl`](https://docs.rs/panproto-lens-dsl) and
+[`panproto-theory-dsl`](https://docs.rs/panproto-theory-dsl) each load declarative
+documents from three formats, and the evaluation machinery is the same for both.
+
+| Extension | Evaluated by |
+|-----------|--------------|
+| `.ncl` | [`nickel-lang`](https://docs.rs/nickel-lang), with a bundled contract library staged on the import path, then deserialized via `to_serde` |
+| `.json` | [`serde_json`](https://docs.rs/serde_json) |
+| `.yaml`, `.yml` | [`yaml_serde`](https://docs.rs/yaml_serde) |
+
+This crate owns the `nickel-lang` and `yaml_serde` dependencies and the
+temp-directory contract staging, so each DSL crate depends on it once instead of
+compiling the Nickel evaluator itself. The functions are generic over the target
+document type: a DSL crate supplies its own document type and contract library,
+and maps `DslEvalError` into its own error type.
+
+## Nickel contracts
+
+A caller embeds its contract library with `include_str!` and passes it as a
+`BundledContract`. The library is written to a temp directory placed first on the
+Nickel import path, so `import "panproto/<file_name>"` resolves during evaluation;
+`file_name` doubles as the source name Nickel reports in diagnostics. Additional
+import paths are appended after it, which lets a document import its own
+neighbours.
+
+Where the Nickel diagnostic carries a source location, it surfaces as
+`DslEvalError::NickelEvalSpanned`, which keeps the evaluated source alongside the
+byte span of the offending token so a caller can render the failure against the
+text it came from.
+
+## Example
+
+```rust,ignore
+use panproto_dsl_eval::{eval_nickel, BundledContract};
+
+let contract = BundledContract {
+    file_name: "lens.ncl",
+    source: include_str!("../contracts/lens.ncl"),
+};
+let document: LensDocument = eval_nickel(source, &[], &contract)?;
+```
+
+## Public API
+
+| Item | Purpose |
+|------|---------|
+| `eval_nickel` | Evaluate a Nickel source against a bundled contract, then deserialize |
+| `eval_json` | Deserialize a JSON source |
+| `eval_yaml` | Deserialize a YAML source |
+| `BundledContract` | A contract library and the file name it is imported under |
+| `DslEvalError` | Nickel evaluation (with and without a span), JSON, YAML, and contract-staging errors |
+
+The underlying configuration language is [Nickel](https://nickel-lang.org).
+
+## License
+
+[MIT](../../LICENSE)


### PR DESCRIPTION
## Summary

`panproto-dsl-eval` was the only one of the twenty-five publishable crates carrying
neither a README file nor a `readme` key, so it rendered on crates.io as a bare
title and its one-line description while every sibling rendered a page. Cargo
auto-detects `README.md`, which is how the siblings declare theirs, so adding the
file is the whole change.

This surfaced while verifying the packaged-crate gate added in #301: that gate
checks every packaged crate declares a licence and ships the README it names, and
this crate passed it by declaring nothing to check.

## Changes

- `crates/panproto-dsl-eval/README.md`: new, following the layout the sibling
  crates use (title, badges, lead, body sections with a table, example, public
  API, licence). It documents the three source formats and their evaluators, and
  the contract staging, which is the part a caller cannot infer from the
  signature: the library is written to `<tmpdir>/panproto/<file_name>` and that
  directory goes first on the Nickel import path, so a document imports it as
  `panproto/<file_name>`. The example mirrors the real call site in
  `panproto-lens-dsl/src/eval.rs`.
- `CHANGELOG.md`: entry under `### Documentation`.

No `readme` key is added, since no sibling declares one and cargo auto-detection
is the established convention here.

## Type of change

- [x] Documentation

## Affected surfaces

- [x] Rust crates (`crates/`) — list which: `panproto-dsl-eval` (packaged metadata only, no code)

## Test plan

Verified by packaging the crate and inspecting the artifact rather than the source,
since the point of the change is what the published `.crate` contains:

```
$ cargo package -p panproto-dsl-eval --no-verify
    Packaged 6 files, 49.3KiB (14.6KiB compressed)

$ tar xzOf target/package/panproto-dsl-eval-0.73.0.crate \
      panproto-dsl-eval-0.73.0/Cargo.toml | grep -E '^(readme|license)'
readme = "README.md"
license = "MIT"

$ tar tzf target/package/panproto-dsl-eval-0.73.0.crate | grep README
panproto-dsl-eval-0.73.0/README.md
```

So cargo auto-detects the file, writes `readme = "README.md"` into the packaged
manifest, and ships it. Running #301's check against that tarball passes.

Every API name, path and structural claim in the README was checked against the
source: the three `eval_*` functions and their signatures, the five `DslEvalError`
variants, `BundledContract`'s fields, the `<tmpdir>/panproto/<file_name>` staging
layout in `write_bundled_contract`, and the `../contracts/lens.ncl` include path
in the example.

- [x] Manual: as above. No code changed, so the Rust suites are unaffected; CI covers them.

## Documentation

- [x] Updated relevant `README.md` files
- [x] Updated CHANGELOG.md under `## [Unreleased]`
