### PR TITLE
docs(ci): let the workflow comments describe the current steps

### DIFF
--- a/.github/workflows/build-panproto-c-bindist.yml
+++ b/.github/workflows/build-panproto-c-bindist.yml
@@ -389,13 +389,15 @@ jobs:
             --manifest-path crates/panproto-c/Cargo.toml
           mkdir -p sbom
 
-          # Name the file. An earlier version of this step used
-          # `find -name '*.cdx.json' | head -1`, which is
-          # nondeterministic across a workspace of 38 of them: it picked
-          # `xtask/xtask.cdx.json`, 20 components, and would have
-          # attested and published xtask's dependency graph labelled as
-          # panproto-c's. Wrong-but-plausible is the failure this step
-          # exists to prevent, so the path is exact.
+          # Name the file rather than searching for one. `cargo
+          # cyclonedx` writes one inventory per workspace member, beside
+          # that member, so a search across this workspace chooses among
+          # 38 candidates and a wrong choice attests and publishes some
+          # other crate's dependency graph labelled as panproto-c's. A
+          # component count cannot catch that, since the wrong file is a
+          # real inventory of the wrong thing; the subject check below
+          # can. Right-looking and wrong is the failure this step exists
+          # to prevent, so the path is exact.
           expected=crates/panproto-c/panproto-c.cdx.json
           test -f "$expected" \
             || { echo "::error::cargo-cyclonedx wrote no $expected"; exit 1; }
@@ -420,11 +422,13 @@ jobs:
 
   release:
     name: Attach to GitHub Release
-    # `sbom` is deliberately absent from `needs`. It was there, and a
-    # bad flag in it meant the v0.73.0 tag attached no archives and no
-    # XCFramework at all, which then stalled `publish-swift.yml` waiting
-    # for one. An inventory that fails to generate is worth reporting;
-    # it is not worth withholding the binaries people install.
+    # `sbom` is deliberately absent from `needs`: a metadata job must
+    # never gate an artifact job. An inventory that fails to generate is
+    # worth reporting; it is not worth withholding the binaries people
+    # install, and withholding them also stalls `publish-swift.yml`,
+    # which waits on the XCFramework this job attaches. The attestation
+    # that consumes the inventory is guarded on the file existing
+    # instead.
     needs: [build, build-ios, build-full, xcframework]
     if: startsWith(github.ref, 'refs/tags/v') || inputs.tag != ''
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,13 +83,13 @@ jobs:
           # Removes Android SDK, .NET, Haskell, large preinstalled
           # tools before any cargo step runs.
           #
-          # The MSRV leg ran out of space anyway on v0.61.0, failing at
-          # `panproto-grammars` with `No space left on device`, and was
-          # cancelled mid-nextest on v0.60.0. The stable leg passed on
-          # identical code both times, so the margin was thin rather
-          # than the budget wrong: trimming more here, and shrinking
-          # what cargo writes (see CARGO_PROFILE_DEV_DEBUG below),
-          # attack the two halves of that.
+          # The MSRV leg is the tight one, and the margin is thin
+          # rather than the budget wrong, so both halves are attacked:
+          # trimming more here, and shrinking what cargo writes (see
+          # CARGO_PROFILE_DEV_DEBUG below). The job reports its
+          # remaining headroom afterwards, because a run that passes
+          # with nothing left is one that fails on the next grammar
+          # added and nothing else would say so.
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /opt/ghc

--- a/.github/workflows/python-wheels-companions.yml
+++ b/.github/workflows/python-wheels-companions.yml
@@ -85,13 +85,12 @@ jobs:
           args: --release --out dist
           manylinux: manylinux_2_28
           before-script-linux: |
-            # A single archive.ubuntu.com blip used to hard-fail the
-            # whole job: on v0.61.0 one aarch64 leg of ~50 could not
-            # fetch perl-base, and because the publish gate needs every
-            # leg green, none of the ten companion wheels published
-            # until someone re-ran it by hand. Package mirrors are the
-            # least reliable thing in this job, so a fetch retries
-            # before it is allowed to fail.
+            # Package mirrors are the least reliable step in this
+            # job, and the publish gate needs every one of some fifty
+            # legs green, so one mirror failure in one leg withholds
+            # every wheel until someone re-runs it by hand. A fetch
+            # therefore retries with a backoff before it is allowed to
+            # fail.
             set -eu
             retry() {
               for attempt in 1 2 3 4 5; do

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -52,13 +52,12 @@ jobs:
           args: --release --out dist
           manylinux: manylinux_2_28
           before-script-linux: |
-            # A single archive.ubuntu.com blip used to hard-fail the
-            # whole job: on v0.61.0 one aarch64 leg of ~50 could not
-            # fetch perl-base, and because the publish gate needs every
-            # leg green, none of the ten companion wheels published
-            # until someone re-ran it by hand. Package mirrors are the
-            # least reliable thing in this job, so a fetch retries
-            # before it is allowed to fail.
+            # Package mirrors are the least reliable step in this
+            # job, and the publish gate needs every one of some fifty
+            # legs green, so one mirror failure in one leg withholds
+            # every wheel until someone re-runs it by hand. A fetch
+            # therefore retries with a backoff before it is allowed to
+            # fail.
             set -eu
             retry() {
               for attempt in 1 2 3 4 5; do
@@ -76,11 +75,11 @@ jobs:
               retry apt-get install -y perl
             fi
       - name: Install the built wheel and run a real operation
-        # A wheel is uploaded to PyPI without anything having installed
-        # it. Source-tree tests cannot see what a wheel omits, and this
-        # binding has shipped that exact defect before: the 0.42.0 wheel
-        # contained only `_native.abi3.so`, with no `__init__.py` and no
-        # `py.typed`, and every check passed.
+        # A wheel would otherwise reach PyPI without anything having
+        # installed it, and source-tree tests cannot see what a wheel
+        # omits: a compiled extension shipped with no `__init__.py` and
+        # no `py.typed` beside it passes every check that reads the
+        # source tree, then fails on a user's first import.
         #
         # Only a wheel whose target the runner can execute is testable
         # here; the cross-compiled aarch64 Linux leg is built under


### PR DESCRIPTION
## Summary

Six comment blocks in the release and CI workflows explained a step by narrating
the incident that prompted it: which releases broke, what the step used to do, and
what the old version would have published. A reader of a workflow wants to know
what the step does and why it is shaped that way. The incident belongs in
`CHANGELOG.md`, which already carries all of it.

Comments only. No step changes, and every comment keeps its reasoning.

## Changes

- `build-panproto-c-bindist.yml`: the `release` job's `needs` comment now states
  the rule (a metadata job must never gate an artifact job, and withholding the
  binaries also stalls `publish-swift.yml`) rather than recounting the tag it
  broke. The SBOM path comment now explains why the path is exact (one inventory
  per workspace member means a search chooses among 38, and a wrong choice is a
  real inventory of the wrong thing, which a component count cannot catch but the
  subject check can) rather than naming the file the old `find` picked.
- `python-wheels.yml`, `python-wheels-companions.yml`: the retry comment now says
  that mirrors are the least reliable step and that one failing leg of some fifty
  withholds every wheel, without naming the release and package that failed.
- `python-wheels.yml`: the wheel-install comment now describes what a source-tree
  test cannot see (a compiled extension with no `__init__.py` or `py.typed` beside
  it passes every check that reads the source tree, then fails on first import)
  rather than citing the version that shipped that way.
- `ci.yml`: the disk-trim comment now states that the MSRV leg is the tight one
  and its margin is thin rather than its budget wrong, and why the headroom is
  reported afterwards, without the per-release failure log.

## Type of change

- [x] Documentation

## Affected surfaces

- [x] CI workflows (`.github/workflows/`)
- [x] Internal only (no published-surface change)

## Test plan

No step changed, so behaviour is unchanged by construction; the diff is entirely
inside `#` comments. Verified:

```
$ git diff origin/main -- .github/workflows | grep '^[+-]' | grep -vE '^[+-]{3}' \
    | grep -vcE '^[+-]\s*#'
0
```

Every added and removed line is a comment line. YAML re-parsed for all seven
workflow files, and a grep for the narration pattern across
`.github/workflows/*.yml` now returns nothing.

- [x] Manual: as above.

## Documentation

- [x] Documentation not required (comments only; the incidents are already in CHANGELOG.md)
