### PR TITLE
fix(ci): correct two release-only steps the v0.74.0 tag exposed

### DIFF
--- a/.github/workflows/build-panproto-c-bindist.yml
+++ b/.github/workflows/build-panproto-c-bindist.yml
@@ -126,9 +126,13 @@ jobs:
           stage="$check/panproto-c-${{ matrix.target }}"
           test -f "$stage/include/panproto.h" || {
             echo "::error::the archive ships no header"; exit 1; }
-          ls "$stage/lib" | grep -q . || {
+          libs=$(ls -A "$stage/lib" 2>/dev/null || true)
+          [ -n "$libs" ] || {
             echo "::error::the archive ships no library"; exit 1; }
-          echo "archive contents:"; find "$stage" -type f | head -20
+          # `sed -n 1,20p` rather than `head -20`: `head` closes the pipe
+          # once it has its lines, and under `pipefail` `find`'s write
+          # error would fail the step on the diagnostic alone.
+          echo "archive contents:"; find "$stage" -type f | sed -n '1,20p'
 
       - name: Expand the archive and check its shape (Windows)
         if: matrix.archive == 'zip'
@@ -168,7 +172,10 @@ jobs:
               return 0;
           }
           C
-          lib=$(ls "$stage"/lib/libpanproto_c.* | head -1)
+          # Glob into an array rather than `ls | head -1`, which fails
+          # the assignment under `pipefail` when `ls` is still writing.
+          libs=("$stage"/lib/libpanproto_c.*)
+          lib="${libs[0]}"
           cc "$RUNNER_TEMP/smoke.c" -I "$stage/include" "$lib" \
              -o "$RUNNER_TEMP/smoke" -lm -lpthread -ldl
           "$RUNNER_TEMP/smoke"

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -94,7 +94,14 @@ jobs:
             # filename; only a quoted value names a file to check for.
             readme=$(sed -n 's/^readme *= *"\([^"]*\)".*/\1/p' <<<"$manifest" || true)
             if [ -n "$readme" ]; then
-              tar tzf "$crate" | grep -qxF "$base/$readme" \
+              # Read the listing into a variable first. Piping into
+              # `grep -q` closes the pipe the moment the name matches,
+              # so `tar` dies on a write error and `pipefail` reports
+              # the pipeline as failed precisely when the file *is*
+              # present. Only large listings lose the race, which is
+              # why this passed everywhere but the biggest crate.
+              listing=$(tar tzf "$crate")
+              grep -qxF "$base/$readme" <<<"$listing" \
                 || { echo "::error::$base names readme $readme but does not ship it"; exit 1; }
             fi
           done
@@ -127,10 +134,11 @@ jobs:
         # failed publish at the existing version.
         run: |
           set -euo pipefail
+          # `sed -n ... p` rather than `grep | head -1`: `head` closes
+          # the pipe early, which under `pipefail` turns the upstream
+          # `grep`'s write error into a failed assignment.
           ws_version=$(grep -A 1 '^\[workspace.package\]' Cargo.toml \
-            | grep '^version' \
-            | head -1 \
-            | cut -d'"' -f2)
+            | sed -n 's/^version *= *"\([^"]*\)".*/\1/p')
           if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
             tag="${GITHUB_REF_NAME#v}"
             if [ "$tag" != "$ws_version" ]; then
@@ -176,9 +184,9 @@ jobs:
               # when the exact version is already on the registry. Match
               # that message directly rather than running a separate
               # `cargo search` (whose output format is unreliable in CI).
-              if echo "$out" | grep -q "already exists on crates.io index"; then
+              if grep -q "already exists on crates.io index" <<<"$out"; then
                 echo "$crate $VERSION already published; continuing"
-              elif echo "$out" | grep -q "do not support creating new crates"; then
+              elif grep -q "do not support creating new crates" <<<"$out"; then
                 # A crate that has never been published cannot be created by a
                 # Trusted Publishing (OIDC) token; crates.io requires an owner
                 # to `cargo publish` it once with an API token, then enable

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -67,8 +67,12 @@ jobs:
           set -euo pipefail
           attempts=360
           for i in $(seq 1 "$attempts"); do
-            if gh release view "$TAG" --json assets \
-                 --jq '.assets[].name' | grep -qx 'panproto_c.xcframework.zip'; then
+            # Capture, then match. Piping `gh` into `grep -q` makes the
+            # condition false when `gh` is killed by the closed pipe,
+            # which would wait out the full two hours for an asset that
+            # is already there.
+            assets=$(gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null || true)
+            if grep -qx 'panproto_c.xcframework.zip' <<<"$assets"; then
               echo "artifact present"
               exit 0
             fi

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -17,16 +17,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # `native` says whether this runner can execute the wheel it
+          # builds, which decides whether the install check below runs.
+          # It is declared here rather than derived from the target name
+          # in an `if:`, so that adding a target has to answer it.
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            native: true
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+            native: false
           - os: macos-latest
             target: aarch64-apple-darwin
+            native: true
           - os: macos-latest
+            # The macOS runners are arm64, so this leg cross-compiles.
             target: x86_64-apple-darwin
+            native: false
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+            native: true
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -82,10 +92,11 @@ jobs:
         # source tree, then fails on a user's first import.
         #
         # Only a wheel whose target the runner can execute is testable
-        # here; the cross-compiled aarch64 Linux leg is built under
-        # emulation-free zigbuild and is skipped rather than pretended
-        # about.
-        if: matrix.target != 'aarch64-unknown-linux-gnu'
+        # here. The cross-compiled legs are skipped rather than
+        # pretended about: pip refuses a wheel whose platform tag does
+        # not match the host, so an x86_64 wheel on the arm64 macOS
+        # runner resolves to nothing at all.
+        if: matrix.native
         shell: bash
         working-directory: bindings/python
         run: |


### PR DESCRIPTION
## Summary

Two release-only steps added in #301 failed on their first real run, which is the
v0.74.0 tag. Neither could fail in CI, because neither executes except on a tag.

### 1. The packaging gate failed when the file it looks for is present

The v0.74.0 crates.io publish failed, and the cause is a bug in the packaging gate
itself rather than in any crate:

```
tar: stdout: write error
##[error]panproto-c-0.74.0 names readme README.md but does not ship it
```

`panproto-c` does ship its README. `grep -q` exits at the first match, which closes
the pipe; `tar` is still writing, so it dies with a write error; and `set -o
pipefail` reports the pipeline as failed. **The check fails precisely when the file
it is looking for is present**, and only when the listing is too large to fit in
the pipe buffer, which is why it hit the largest of the twenty-five crates and
passed on the rest, and why it passed locally on macOS where `bsdtar` buffered the
whole listing.

The gate did its job: `Publish workspace crates` was skipped and nothing reached
the registry.

## Changes

Seven instances of the same shape, across three workflows.

| File | Was | Now |
|---|---|---|
| `publish-crates.yml` | `tar tzf … \| grep -qxF …` | capture listing, then `grep -qxF <<<` |
| `publish-crates.yml` | `grep … \| head -1 \| cut` | `grep … \| sed -n 's/…/\1/p'` |
| `publish-crates.yml` | `echo "$out" \| grep -q …` (×2) | `grep -q … <<<"$out"` |
| `build-panproto-c-bindist.yml` | `ls "$stage/lib" \| grep -q .` | `libs=$(ls -A …)`, test non-empty |
| `build-panproto-c-bindist.yml` | `find … \| head -20` | `find … \| sed -n '1,20p'` |
| `publish-swift.yml` | `gh … \| grep -qx …` | capture assets, then `grep -qx <<<` |

Two of those were latent **logic** errors, not just spurious failures:

- `publish-swift.yml` decides whether the XCFramework has been attached with that
  pipeline. A `gh` killed by the closed pipe makes the condition false, so the job
  would wait out its full two-hour bound for an asset that is already there.
- The bindist C smoke test selects its library with `ls | head -1`, inside a
  command substitution under `pipefail`.

The rule applied throughout is to capture into a variable and then match, which is
the form the surrounding code already used one line above for the manifest. Where
the consumer has to stay in a pipeline, `sed -n '1,Np'` replaces `head -N`, because
sed reads its input to the end.

### 2. The wheel install check ran on a leg that cannot run its own wheel

`Python Wheels` failed on `x86_64-apple-darwin` with

```
ERROR: Could not find a version that satisfies the requirement panproto (from versions: none)
```

for a wheel sitting in the directory pip was pointed at. The macOS runners are
arm64 (`Image: macos-26-arm64`), so that leg cross-compiles and produces
`panproto-0.74.0-cp313-abi3-macosx_10_12_x86_64.whl`, which pip correctly refuses
on an arm64 host. The step skipped the cross-compiled leg by naming it, and named
only the Linux one.

The matrix now carries `native` per leg and the step reads `if: matrix.native`, so
whether a runner can execute its own wheel is stated once beside the target instead
of being re-derived from the target's name. Adding a target now has to answer it.

| os | target | native |
|---|---|---|
| ubuntu-latest | x86_64-unknown-linux-gnu | true |
| ubuntu-latest | aarch64-unknown-linux-gnu | false |
| macos-latest | aarch64-apple-darwin | true |
| macos-latest | x86_64-apple-darwin | false |
| windows-latest | x86_64-pc-windows-msvc | true |

## Type of change

- [x] Bug fix (non-breaking)
- [x] Build / CI / release infrastructure

## Affected surfaces

- [x] CI workflows (`.github/workflows/`)

## Test plan

The hazard and the fix, both executed rather than reasoned about:

```
$ bash -c 'set -uo pipefail; seq 1 2000000 | grep -q "^1$"; echo "exit: $?"'
exit: 141                     # 128 + 13 = SIGPIPE, though grep matched

$ bash -c 'set -uo pipefail; listing=$(seq 1 2000000); grep -qxF 1 <<<"$listing"; echo "exit: $?"'
exit: 0
```

The corrected gate loop, run with `set -euo pipefail` against all 25 packaged
crates built from this tree:

```
$ cargo package <25 × -p> --no-verify
$ <the fixed licence/README loop>
all 25 packaged crates declare a licence and ship their README
loop exit: 0
```

And the replacement version extraction:

```
$ grep -A 1 '^\[workspace.package\]' Cargo.toml | sed -n 's/^version *= *"\([^"]*\)".*/\1/p'
0.74.0
```

- [x] Manual: as above. All seven workflow files re-parsed as YAML.

## Documentation

- [x] Documentation not required (CI fix; no user-facing change)