### PR TITLE
fix(gat): check a case against the result sort, not against its first branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to panproto will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **An eliminator's result sort may now mention the index it eliminates** (`panproto-gat`): dependent pattern matching decides which branches a `case` requires from the scrutinee's index, and that half worked, so `head : (n: Nat, Vec(succ n)) -> A` typechecked. The other half did not: every branch body still had to have one shared sort, so `eval : (t: Ty, Expr(t)) -> El(t)` was rejected for branches producing `El(int_code)` and `El(bool_code)`, neither of which is wrong. A `case` carries no motive, so with nothing expected the only sort available was the one read off the first branch, and the rest were compared to that. Sorts are now checked as well as inferred: an equation checks one side against the other's sort, which makes the declared output sort of the operation being defined available as the motive, and each branch body is checked against that motive refined by the same substitution the branch already applies to its binders. Branches are measured against the result sort rather than against each other. The refinement was already computed and already applied to the binders; it simply had nothing to apply to on the result side. Nothing that typechecked before stops doing so: with a result sort that does not mention the index the substitution does not touch the motive and every branch checks against the same sort, and where no expected sort is available the first branch still fixes it. A branch that misses the motive is now reported as `case branch \`BoolLit\` has sort El(int_code()), expected El(bool_code()) under this branch's refinement`, naming the branch at fault instead of two branch sorts that were never required to agree.
+
 ## [0.74.0] - 2026-09-10
 
 ### Security

--- a/crates/panproto-gat/src/error.rs
+++ b/crates/panproto-gat/src/error.rs
@@ -419,6 +419,26 @@ pub enum GatError {
         scrutinee_sort: String,
     },
 
+    /// A case branch body's sort does not match the expected result
+    /// sort refined by that branch's own index substitution.
+    ///
+    /// Reported instead of comparing branches to each other, so the
+    /// message names the branch at fault and the sort the motive
+    /// requires there, rather than two branch sorts that were never
+    /// required to agree.
+    #[error(
+        "case branch `{constructor}` has sort {got}, expected {expected} \
+         under this branch's refinement"
+    )]
+    CaseBranchSortMismatch {
+        /// The branch's constructor.
+        constructor: String,
+        /// The result sort refined by this branch's substitution.
+        expected: String,
+        /// The sort the branch body actually has.
+        got: String,
+    },
+
     /// A case expression's scrutinee sort admits no constructor, so the
     /// expression has no branch to take its sort from.
     ///

--- a/crates/panproto-gat/src/lib.rs
+++ b/crates/panproto-gat/src/lib.rs
@@ -81,7 +81,7 @@ pub use sort::{
 };
 pub use theory::{ConflictPolicy, ConflictStrategy, Theory, resolve_theory, th_editable_structure};
 pub use typecheck::{
-    HoleReport, SortScheme, VarContext, infer_var_sorts, typecheck_equation,
+    HoleReport, SortScheme, VarContext, check_term, infer_var_sorts, typecheck_equation,
     typecheck_equation_modulo_rewrites, typecheck_term, typecheck_term_with_holes,
     typecheck_theory,
 };

--- a/crates/panproto-gat/src/typecheck.rs
+++ b/crates/panproto-gat/src/typecheck.rs
@@ -109,6 +109,52 @@ pub fn typecheck_term(
     ctx: &VarContext,
     theory: &Theory,
 ) -> Result<SortExpr, GatError> {
+    check_term_opt(term, None, ctx, theory)
+}
+
+/// Typecheck `term` against a known expected sort.
+///
+/// Inference alone cannot type an eliminator whose result sort mentions
+/// the index it eliminates. A `Case` has no motive of its own, so with
+/// nothing expected the only sort available is the one read off the
+/// first branch, and every later branch is then required to agree with
+/// it. For `eval : (t: Ty, Expr(t)) -> El(t)` the branches produce
+/// `El(int_code)` and `El(bool_code)`, which do not agree and should
+/// not have to: each is correct under its own branch's refinement.
+///
+/// Given an expected sort, each branch body is instead checked against
+/// that sort refined by the same substitution the branch already
+/// applies to its binders, so the branches are compared to the motive
+/// rather than to each other. The expected sort is the declared output
+/// of whatever operation the equation defines, which is what makes the
+/// motive available without putting one in the `Term` AST.
+///
+/// Every other term shape is inferred exactly as [`typecheck_term`]
+/// does, and the returned sort is left for the caller to compare, so
+/// this never rejects anything [`typecheck_term`] accepts.
+///
+/// # Errors
+///
+/// As [`typecheck_term`], plus [`GatError::CaseBranchSortMismatch`]
+/// when a branch body does not have the expected sort under its own
+/// refinement.
+pub fn check_term(
+    term: &Term,
+    expected: &SortExpr,
+    ctx: &VarContext,
+    theory: &Theory,
+) -> Result<SortExpr, GatError> {
+    check_term_opt(term, Some(expected), ctx, theory)
+}
+
+/// Shared core of [`typecheck_term`] and [`check_term`]. `expected` is
+/// `None` in inference mode.
+fn check_term_opt(
+    term: &Term,
+    expected: Option<&SortExpr>,
+    ctx: &VarContext,
+    theory: &Theory,
+) -> Result<SortExpr, GatError> {
     match term {
         Term::Var(name) => ctx
             .get(name)
@@ -147,7 +193,7 @@ pub fn typecheck_term(
         Term::Case {
             scrutinee,
             branches,
-        } => typecheck_case(scrutinee, branches, ctx, theory),
+        } => typecheck_case(scrutinee, branches, expected, ctx, theory),
 
         Term::Let { name, bound, body } => {
             // Typecheck the bound term, extend the context with the
@@ -161,15 +207,26 @@ pub fn typecheck_term(
             let bound_sort = typecheck_term(bound, ctx, theory)?;
             let mut extended = ctx.clone();
             extended.insert(Arc::clone(name), bound_sort);
-            typecheck_term(body, &extended, theory)
+            // The body's sort is the `let`'s sort, so an expected sort
+            // passes straight through to it.
+            check_term_opt(body, expected, &extended, theory)
         }
     }
 }
 
-/// Typecheck a [`Term::Case`] expression.
+/// Typecheck a [`Term::Case`] expression, against `expected` when one
+/// is known.
+///
+/// With an expected sort, each branch body is checked against it
+/// refined by that branch's own substitution, which is what lets the
+/// result sort mention the index being eliminated. Without one, the
+/// first branch's sort fixes the case's sort and the rest must match
+/// it, which is the only thing that can be done when no motive is
+/// available.
 fn typecheck_case(
     scrutinee: &Term,
     branches: &[CaseBranch],
+    expected: Option<&SortExpr>,
     ctx: &VarContext,
     theory: &Theory,
 ) -> Result<SortExpr, GatError> {
@@ -191,9 +248,9 @@ fn typecheck_case(
     // admits, rather than over every constructor the sort declares.
     check_case_exhaustiveness(&scrutinee_sort, &constructors, branches, theory)?;
 
-    // Typecheck each branch body; all must produce alpha-equivalent
-    // output sorts. The first branch's output sort is the case
-    // expression's sort.
+    // Typecheck each branch body. Against a known motive each is
+    // checked under its own refinement; otherwise the first branch's
+    // output sort fixes the case's sort and the rest must match it.
     let mut branch_sort: Option<SortExpr> = None;
     for b in branches {
         let constructor_op = theory
@@ -232,6 +289,23 @@ fn typecheck_case(
         for ((_, declared_sort, _), binder) in constructor_op.inputs.iter().zip(b.binders.iter()) {
             let binder_sort = declared_sort.subst(&subst);
             extended.insert(Arc::clone(binder), binder_sort);
+        }
+        if let Some(motive) = expected {
+            // The same `subst` that refined the binders refines the
+            // motive, so `El(t)` is `El(int_code)` in the `IntLit`
+            // branch. Branches are compared to this, never to one
+            // another.
+            let refined = motive.subst(&subst);
+            let body_sort = check_term(&b.body, &refined, &extended, theory)?;
+            if !body_sort.alpha_eq(&refined) {
+                return Err(GatError::CaseBranchSortMismatch {
+                    constructor: b.constructor.to_string(),
+                    expected: refined.to_string(),
+                    got: body_sort.to_string(),
+                });
+            }
+            branch_sort = Some(motive.clone());
+            continue;
         }
         let body_sort = typecheck_term(&b.body, &extended, theory)?;
         match &branch_sort {
@@ -730,7 +804,7 @@ fn typecheck_with_expected(
         Term::Case {
             scrutinee,
             branches,
-        } => typecheck_case_with_holes(scrutinee, branches, ctx, theory, reports),
+        } => typecheck_case_with_holes(scrutinee, branches, expected, ctx, theory, reports),
         Term::Let { name, bound, body } => {
             let bound_sort = typecheck_with_expected(bound, None, ctx, theory, reports)?;
             let mut extended = ctx.clone();
@@ -743,6 +817,7 @@ fn typecheck_with_expected(
 fn typecheck_case_with_holes(
     scrutinee: &Term,
     branches: &[CaseBranch],
+    expected: Option<&SortExpr>,
     ctx: &VarContext,
     theory: &Theory,
     reports: &mut Vec<HoleReport>,
@@ -788,6 +863,24 @@ fn typecheck_case_with_holes(
         for ((_, declared_sort, _), binder) in constructor_op.inputs.iter().zip(b.binders.iter()) {
             let binder_sort = declared_sort.subst(&subst);
             extended.insert(Arc::clone(binder), binder_sort);
+        }
+        if let Some(motive) = expected {
+            // Mirror the strict path: compare each branch to the motive
+            // refined by that branch's substitution. A hole in a branch
+            // body then reports the sort the motive requires there
+            // rather than a metavariable.
+            let refined = motive.subst(&subst);
+            let body_sort =
+                typecheck_with_expected(&b.body, Some(&refined), &extended, theory, reports)?;
+            if !term_contains_hole(&b.body) && !body_sort.alpha_eq(&refined) {
+                return Err(GatError::CaseBranchSortMismatch {
+                    constructor: b.constructor.to_string(),
+                    expected: refined.to_string(),
+                    got: body_sort.to_string(),
+                });
+            }
+            branch_sort = Some(motive.clone());
+            continue;
         }
         let body_sort = typecheck_with_expected(&b.body, None, &extended, theory, reports)?;
         match &branch_sort {
@@ -966,8 +1059,21 @@ pub fn typecheck_equation(eq: &Equation, theory: &Theory) -> Result<(), GatError
         });
     }
     let ctx = infer_var_sorts(eq, theory)?;
-    let lhs_sort = typecheck_term(&eq.lhs, &ctx, theory)?;
-    let rhs_sort = typecheck_term(&eq.rhs, &ctx, theory)?;
+    // Check one side against the other's sort rather than inferring
+    // both: the declared output sort of the operation being defined is
+    // the motive a `Case` needs, and it reaches the `Case` only if it
+    // is pushed in. Whichever side is not itself a `Case` is inferred
+    // first, so the direction does not matter to the writer.
+    let (lhs_sort, rhs_sort) =
+        if matches!(eq.lhs, Term::Case { .. }) && !matches!(eq.rhs, Term::Case { .. }) {
+            let rhs_sort = typecheck_term(&eq.rhs, &ctx, theory)?;
+            let lhs_sort = check_term(&eq.lhs, &rhs_sort, &ctx, theory)?;
+            (lhs_sort, rhs_sort)
+        } else {
+            let lhs_sort = typecheck_term(&eq.lhs, &ctx, theory)?;
+            let rhs_sort = check_term(&eq.rhs, &lhs_sort, &ctx, theory)?;
+            (lhs_sort, rhs_sort)
+        };
     if !lhs_sort.alpha_eq(&rhs_sort) {
         return Err(GatError::EquationSortMismatch {
             equation: eq.name.to_string(),
@@ -1005,8 +1111,21 @@ pub fn typecheck_equation_modulo_rewrites(
         });
     }
     let ctx = infer_var_sorts(eq, theory)?;
-    let lhs_sort = typecheck_term(&eq.lhs, &ctx, theory)?;
-    let rhs_sort = typecheck_term(&eq.rhs, &ctx, theory)?;
+    // Check one side against the other's sort rather than inferring
+    // both: the declared output sort of the operation being defined is
+    // the motive a `Case` needs, and it reaches the `Case` only if it
+    // is pushed in. Whichever side is not itself a `Case` is inferred
+    // first, so the direction does not matter to the writer.
+    let (lhs_sort, rhs_sort) =
+        if matches!(eq.lhs, Term::Case { .. }) && !matches!(eq.rhs, Term::Case { .. }) {
+            let rhs_sort = typecheck_term(&eq.rhs, &ctx, theory)?;
+            let lhs_sort = check_term(&eq.lhs, &rhs_sort, &ctx, theory)?;
+            (lhs_sort, rhs_sort)
+        } else {
+            let lhs_sort = typecheck_term(&eq.lhs, &ctx, theory)?;
+            let rhs_sort = check_term(&eq.rhs, &lhs_sort, &ctx, theory)?;
+            (lhs_sort, rhs_sort)
+        };
     let (equal, exhausted) = lhs_sort.alpha_eq_modulo_rewrites_status(&rhs_sort, rules, step_limit);
     if !equal {
         if exhausted {

--- a/crates/panproto-gat/tests/dependent_motive.rs
+++ b/crates/panproto-gat/tests/dependent_motive.rs
@@ -1,0 +1,209 @@
+//! Elimination whose result sort mentions the index being eliminated.
+//!
+//! A `Case` carries no motive, so with nothing expected the only sort
+//! available is the one read off the first branch, and every later
+//! branch has to agree with it. That is exactly what an eliminator over
+//! an indexed family cannot do: in `eval : (t: Ty, Expr(t)) -> El(t)`
+//! the `IntLit` branch has sort `El(int_code)` and the `BoolLit` branch
+//! `El(bool_code)`, and neither is wrong.
+//!
+//! Pushing the declared output sort in as the motive turns the
+//! comparison around: each branch is checked against the motive refined
+//! by that branch's own substitution, so the branches are measured
+//! against the result sort rather than against each other.
+//!
+//! The theory is a universe of two codes, `Expr(t)` closed over one
+//! literal per code, and `El(t)` for the values.
+
+use std::sync::Arc;
+
+use panproto_gat::{
+    CaseBranch, Equation, GatError, Implicit, Operation, Sort, SortExpr, SortParam, Term, Theory,
+    typecheck_theory,
+};
+
+fn el_of(index: Term) -> SortExpr {
+    SortExpr::App {
+        name: Arc::from("El"),
+        args: vec![index],
+    }
+}
+
+fn expr_of(index: Term) -> SortExpr {
+    SortExpr::App {
+        name: Arc::from("Expr"),
+        args: vec![index],
+    }
+}
+
+fn int_code() -> Term {
+    Term::app("int_code", vec![])
+}
+
+fn bool_code() -> Term {
+    Term::app("bool_code", vec![])
+}
+
+/// `Ty` closed over two codes, `Expr(t)` closed over one literal each,
+/// `El(t)` for values, and `R` for a result that ignores the index.
+/// Only the equation under test varies.
+fn expr_theory(eqs: Vec<Equation>) -> Theory {
+    let ty = Sort::closed(
+        "Ty",
+        Vec::new(),
+        [Arc::from("int_code") as Arc<str>, Arc::from("bool_code")],
+    );
+    let el = Sort::dependent("El", vec![SortParam::new("t", "Ty")]);
+    let expr = Sort::closed(
+        "Expr",
+        vec![SortParam::new("t", "Ty")],
+        [Arc::from("IntLit") as Arc<str>, Arc::from("BoolLit")],
+    );
+    let r = Sort::simple("R");
+
+    let ops = vec![
+        Operation::nullary("int_code", "Ty"),
+        Operation::nullary("bool_code", "Ty"),
+        Operation {
+            name: Arc::from("IntLit"),
+            inputs: vec![(Arc::from("v"), el_of(int_code()), Implicit::No)],
+            output: expr_of(int_code()),
+        },
+        Operation {
+            name: Arc::from("BoolLit"),
+            inputs: vec![(Arc::from("v"), el_of(bool_code()), Implicit::No)],
+            output: expr_of(bool_code()),
+        },
+        Operation::nullary("tag", "R"),
+        // A value at a fixed code, for writing a branch that returns
+        // the wrong thing on purpose.
+        Operation::nullary("mkint", el_of(int_code())),
+        // The result sort mentions the index.
+        Operation {
+            name: Arc::from("eval"),
+            inputs: vec![
+                (Arc::from("t"), SortExpr::from("Ty"), Implicit::No),
+                (Arc::from("e"), expr_of(Term::var("t")), Implicit::No),
+            ],
+            output: el_of(Term::var("t")),
+        },
+        // The result sort ignores it.
+        Operation {
+            name: Arc::from("describe"),
+            inputs: vec![
+                (Arc::from("t"), SortExpr::from("Ty"), Implicit::No),
+                (Arc::from("e"), expr_of(Term::var("t")), Implicit::No),
+            ],
+            output: SortExpr::from("R"),
+        },
+    ];
+
+    Theory::new("ExprTh", vec![ty, el, expr, r], ops, eqs)
+}
+
+fn branches(int_body: Term, bool_body: Term) -> Vec<CaseBranch> {
+    vec![
+        CaseBranch {
+            constructor: Arc::from("IntLit"),
+            binders: vec![Arc::from("v")],
+            body: int_body,
+        },
+        CaseBranch {
+            constructor: Arc::from("BoolLit"),
+            binders: vec![Arc::from("v")],
+            body: bool_body,
+        },
+    ]
+}
+
+/// `<op>(t, e) = case e of ...`.
+fn def_eq(op: &str, int_body: Term, bool_body: Term) -> Equation {
+    Equation::new(
+        format!("{op}_def"),
+        Term::app(op, vec![Term::var("t"), Term::var("e")]),
+        Term::Case {
+            scrutinee: Box::new(Term::var("e")),
+            branches: branches(int_body, bool_body),
+        },
+    )
+}
+
+/// The case the issue reports. Each branch returns its own bound value,
+/// whose sort is the motive refined by that branch: `El(int_code)` in
+/// the `IntLit` branch and `El(bool_code)` in the `BoolLit` branch.
+#[test]
+fn a_result_sort_that_mentions_the_index_typechecks() {
+    let theory = expr_theory(vec![def_eq("eval", Term::var("v"), Term::var("v"))]);
+    let result = typecheck_theory(&theory);
+    assert!(
+        result.is_ok(),
+        "eval : (t, Expr(t)) -> El(t) should typecheck, got {result:?}",
+    );
+}
+
+/// The branches have genuinely different sorts here, and both are
+/// correct. Nothing in the checker may require them to agree.
+#[test]
+fn branches_are_measured_against_the_motive_not_against_each_other() {
+    let theory = expr_theory(vec![def_eq("eval", Term::var("v"), Term::var("v"))]);
+    assert!(typecheck_theory(&theory).is_ok());
+
+    // Swapping the bodies makes each branch return the other's sort,
+    // which no refinement licenses.
+    let swapped = expr_theory(vec![def_eq(
+        "eval",
+        Term::app("mkint", vec![]),
+        Term::app("mkint", vec![]),
+    )]);
+    let result = typecheck_theory(&swapped);
+    let Err(GatError::CaseBranchSortMismatch {
+        ref constructor, ..
+    }) = result
+    else {
+        panic!(
+            "a branch returning El(int_code) where El(bool_code) is required must fail, got {result:?}"
+        );
+    };
+    assert_eq!(constructor.as_str(), "BoolLit");
+}
+
+/// The non-dependent path is unchanged: with a result sort that does
+/// not mention the index, the refinement does not touch the motive and
+/// every branch checks against the same sort.
+#[test]
+fn a_result_sort_that_ignores_the_index_still_typechecks() {
+    let theory = expr_theory(vec![def_eq(
+        "describe",
+        Term::app("tag", vec![]),
+        Term::app("tag", vec![]),
+    )]);
+    let result = typecheck_theory(&theory);
+    assert!(
+        result.is_ok(),
+        "describe : (t, Expr(t)) -> R should typecheck, got {result:?}",
+    );
+}
+
+/// A branch that does not produce the declared result sort is still
+/// rejected, and the error names the branch and the sort the motive
+/// requires there rather than two branch sorts.
+#[test]
+fn a_branch_that_misses_the_motive_is_rejected_by_name() {
+    let theory = expr_theory(vec![def_eq(
+        "describe",
+        Term::app("tag", vec![]),
+        Term::app("mkint", vec![]),
+    )]);
+    let result = typecheck_theory(&theory);
+    let Err(GatError::CaseBranchSortMismatch {
+        ref constructor,
+        ref expected,
+        ref got,
+    }) = result
+    else {
+        panic!("a branch returning El(int_code) where R is required must fail, got {result:?}");
+    };
+    assert_eq!(constructor.as_str(), "BoolLit");
+    assert_eq!(expected.as_str(), "R");
+    assert_eq!(got.as_str(), "El(int_code())");
+}


### PR DESCRIPTION
## Summary

Closes #309.

Dependent pattern matching decides *which* branches a `case` requires from the
scrutinee's index, and that half already worked, so
`head : (n: Nat, Vec(succ n)) -> A` typechecked. The other half did not: a `case`
carries no motive, so with nothing expected the only sort available was the one
read off the first branch, and every later branch had to agree with it. For
`eval : (t: Ty, Expr(t)) -> El(t)` the branches have sorts `El(int_code)` and
`El(bool_code)` and neither is wrong, so the eliminator was unwritable.

Sorts are now checked as well as inferred. An equation checks one side against the
other's sort, which is what makes the declared output sort of the operation being
defined available as the motive, and each branch body is checked against that
motive refined by the same substitution the branch already applies to its binders.
Branches are measured against the result sort rather than against each other.

The refinement was already computed and already used for the binders; it simply had
nothing to apply to on the result side.

## Changes

- `typecheck.rs`: `typecheck_term` now delegates to a shared `check_term_opt` core
  carrying `expected: Option<&SortExpr>`. New public `check_term` supplies one.
  Every term shape except `Case` infers exactly as before and leaves the comparison
  to the caller, so checking mode never rejects what inference accepted.
- `typecheck_case` takes the expected sort. With one, each branch body is checked
  against `motive.subst(&subst)` and the case's sort is the motive; without one,
  the first branch still fixes the sort and the rest must match, unchanged.
- `typecheck_equation` and `typecheck_equation_modulo_rewrites` infer one side and
  check the other against it. Whichever side is not itself a `Case` is inferred
  first, so an equation written `case … = eval(t, e)` works as well as the usual
  direction.
- `typecheck_case_with_holes` gets the same treatment, so a hole in a branch body
  reports the sort the motive requires there instead of a metavariable.
- `Term::Let` propagates the expected sort to its body, since the body's sort is
  the `let`'s sort.
- New `GatError::CaseBranchSortMismatch { constructor, expected, got }`.

## Type of change

- [x] Bug fix (non-breaking)

## Affected surfaces

- [x] Rust crates (`crates/`) — list which: `panproto-gat`

Additive only: a new `pub fn check_term`, and a new variant on `GatError`, which is
`#[non_exhaustive]`. No existing signature changes, so no version bump.

## Linked issues

- Closes #309

## Test plan

**The reported reproduction, before and after.** Against the published 0.74.0 wheel:

```
describe -> R      (result ignores the index)  ACCEPTED
eval -> El(t)      (result mentions the index)  REJECTED: theory typecheck failed:
  equation case sides have different sorts: lhs=El(int_code()), rhs=El(bool_code())
```

Against this branch, built with `maturin develop --release`:

```
describe -> R      (result ignores the index)  ACCEPTED
eval -> El(t)      (result mentions the index)  ACCEPTED
```

**Checked that it does not over-accept.** Five variants through the Python API:

```
must be ACCEPTED:
  ok  eval, each branch matches its refined motive: ACCEPTED
  ok  describe, non-dependent, branches agree: ACCEPTED
must be REJECTED:
  ok  eval, BoolLit branch returns an int: REJECTED
        case branch `BoolLit` has sort El(int_code()), expected El(bool_code()) under this branch's refinement
  ok  describe, branches disagree: REJECTED
        case branch `BoolLit` has sort El(int_code()), expected R under this branch's refinement
  ok  eval, both branches return El(int_code): REJECTED
        case branch `BoolLit` has sort El(int_code()), expected El(bool_code()) under this branch's refinement
```

The diagnostics also improve: the error names the branch at fault and the sort the
motive requires there, rather than two branch sorts that were never required to
agree.

**New test file** `crates/panproto-gat/tests/dependent_motive.rs`, 4 tests:
a result sort that mentions the index typechecks; branches are measured against the
motive and not against each other; a result sort that ignores the index still
typechecks (the non-dependent regression guard); a branch that misses the motive is
rejected by name.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p panproto-gat --no-deps`
- [ ] `cargo nextest run --workspace` — **not run locally.** The machine ran out of
      disk twice building it (`No space left on device`, then `ld: write() failed,
      errno=28`), with the volume around 90% full from unrelated data. Run instead:
      `panproto-gat` (419 tests) and the crates that depend on it directly
      (`panproto-gat-macros`, `panproto-theory-dsl`, `panproto-schema`,
      `panproto-inst`, `panproto-check`, `panproto-lens-dsl`):

      ```
      Summary [18.581s] 952 tests run: 952 passed, 0 skipped
      ```

      The full workspace sweep is CI's on this PR; please don't merge on the
      strength of the boxes above alone.

## Known limitation

A `case` in *argument* position (`f(case e of …)`) still gets no motive and falls
back to first-branch inference, because `typecheck_app_explicit` infers each
argument before computing its expected sort. Nothing in the repo constructs one, and
the issue scopes the fix to the eliminators that arise from equations, so this is
left alone rather than changed speculatively.

## Documentation

- [x] Updated CHANGELOG.md under `## [Unreleased]`
- [x] Updated docstrings / rustdoc on changed public items
