### PR TITLE
fix(core): restore indexed migration compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to panproto will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **Historical content-addressed objects retain their original identities** (`panproto-vcs`, `panproto-xrpc`): filesystem and remote reads validated a decoded object by serializing it again with the current type definition. A commit written before the `unverified` field existed therefore gained an empty field during decoding and hashed to a new ID, so intact repositories created by Panproto 0.58 were reported as corrupted by 0.74.1. Directly serialized object kinds are now validated against the payload bytes that were actually stored or received. Every byte remains covered by blake3, substituted objects are still refused, and current writes keep their existing addresses.
+
+- **Equations may invoke operations with inferred arguments** (`panproto-gat`): ordinary term checking counted only explicit arguments, while equation-variable inference counted implicit and explicit parameters together. Thus a well-typed indexed eliminator could be called normally but its defining equation failed with an arity error. Both paths now align supplied terms with the explicit telescope and introduce fresh, call-local metavariables for implicit parameters, so equations recover the same indices as ordinary applications.
+
 ## [0.74.1] - 2026-09-10
 
 ### Bug Fixes

--- a/crates/panproto-gat/src/typecheck.rs
+++ b/crates/panproto-gat/src/typecheck.rs
@@ -499,8 +499,21 @@ fn push_sort_expr_eqs_into(
 pub fn infer_var_sorts(eq: &Equation, theory: &Theory) -> Result<VarContext, GatError> {
     let mut ctx = VarContext::default();
     let mut term_eqs: Vec<(Term, Term)> = Vec::new();
-    collect_constraints(&eq.lhs, theory, &mut ctx, &mut term_eqs)?;
-    collect_constraints(&eq.rhs, theory, &mut ctx, &mut term_eqs)?;
+    let mut next_implicit_scope = 0;
+    collect_constraints(
+        &eq.lhs,
+        theory,
+        &mut ctx,
+        &mut term_eqs,
+        &mut next_implicit_scope,
+    )?;
+    collect_constraints(
+        &eq.rhs,
+        theory,
+        &mut ctx,
+        &mut term_eqs,
+        &mut next_implicit_scope,
+    )?;
 
     let substitution = unify_all(term_eqs)?;
     if !substitution.is_empty() {
@@ -520,6 +533,7 @@ fn collect_constraints(
     theory: &Theory,
     ctx: &mut VarContext,
     term_eqs: &mut Vec<(Term, Term)>,
+    next_implicit_scope: &mut usize,
 ) -> Result<(), GatError> {
     let (op, args) = match term {
         Term::App { op, args } => (op, args),
@@ -527,15 +541,15 @@ fn collect_constraints(
             scrutinee,
             branches,
         } => {
-            collect_constraints(scrutinee, theory, ctx, term_eqs)?;
+            collect_constraints(scrutinee, theory, ctx, term_eqs, next_implicit_scope)?;
             for b in branches {
-                collect_constraints(&b.body, theory, ctx, term_eqs)?;
+                collect_constraints(&b.body, theory, ctx, term_eqs, next_implicit_scope)?;
             }
             return Ok(());
         }
         Term::Let { bound, body, .. } => {
-            collect_constraints(bound, theory, ctx, term_eqs)?;
-            collect_constraints(body, theory, ctx, term_eqs)?;
+            collect_constraints(bound, theory, ctx, term_eqs, next_implicit_scope)?;
+            collect_constraints(body, theory, ctx, term_eqs, next_implicit_scope)?;
             return Ok(());
         }
         Term::Var(_) | Term::Hole { .. } => return Ok(()),
@@ -544,16 +558,38 @@ fn collect_constraints(
         .find_op(op)
         .ok_or_else(|| GatError::OpNotFound(op.to_string()))?;
 
-    if args.len() != operation.inputs.len() {
+    let explicit_count = operation.explicit_arity();
+    if args.len() != explicit_count {
         return Err(GatError::TermArityMismatch {
             op: op.to_string(),
-            expected: operation.inputs.len(),
+            expected: explicit_count,
             got: args.len(),
         });
     }
 
     let mut theta: FxHashMap<Arc<str>, Term> = FxHashMap::default();
-    for (arg, (param_name, declared_sort, _)) in args.iter().zip(operation.inputs.iter()) {
+    let implicit_scope = *next_implicit_scope;
+    *next_implicit_scope += 1;
+    for (index, (param_name, _, implicit)) in operation.inputs.iter().enumerate() {
+        if matches!(implicit, Implicit::Yes) {
+            let metavariable: Arc<str> =
+                Arc::from(format!("?{op}_{param_name}_{implicit_scope}_{index}"));
+            theta.insert(Arc::clone(param_name), Term::Var(metavariable));
+        }
+    }
+
+    let mut explicit_args = args.iter();
+    for (param_name, declared_sort, implicit) in &operation.inputs {
+        if matches!(implicit, Implicit::Yes) {
+            continue;
+        }
+        let Some(arg) = explicit_args.next() else {
+            return Err(GatError::TermArityMismatch {
+                op: op.to_string(),
+                expected: explicit_count,
+                got: args.len(),
+            });
+        };
         let expected = declared_sort.subst(&theta);
         match arg {
             Term::Var(var_name) => {
@@ -564,7 +600,7 @@ fn collect_constraints(
                 }
             }
             Term::App { .. } | Term::Case { .. } | Term::Hole { .. } | Term::Let { .. } => {
-                collect_constraints(arg, theory, ctx, term_eqs)?;
+                collect_constraints(arg, theory, ctx, term_eqs, next_implicit_scope)?;
             }
         }
         theta.insert(Arc::clone(param_name), arg.clone());
@@ -2606,6 +2642,27 @@ mod tests {
         ctx.insert(Arc::from("x"), SortExpr::from("Ob"));
         let result = typecheck_term(&Term::app("id", vec![Term::var("x")]), &ctx, &theory)?;
         assert_eq!(&**result.head(), "Hom");
+        Ok(())
+    }
+
+    #[test]
+    fn equation_applications_infer_implicit_arguments() -> Result<(), Box<dyn std::error::Error>> {
+        let mut theory = lambda_theory();
+        theory.eqs.push(Equation::new(
+            "app_reflexive",
+            Term::app("app", vec![Term::var("f"), Term::var("x")]),
+            Term::app("app", vec![Term::var("f"), Term::var("x")]),
+        ));
+
+        let context = infer_var_sorts(&theory.eqs[0], &theory)?;
+        assert_eq!(
+            context.len(),
+            2,
+            "only explicit equation variables are bound"
+        );
+        assert_eq!(context[&Arc::from("f")].head().as_ref(), "Tm");
+        assert_eq!(context[&Arc::from("x")].head().as_ref(), "Tm");
+        typecheck_theory(&theory)?;
         Ok(())
     }
 

--- a/crates/panproto-vcs/src/fs_store.rs
+++ b/crates/panproto-vcs/src/fs_store.rs
@@ -147,7 +147,7 @@ impl Store for FsStore {
         // must hash back to it. Re-deriving the address on read turns a
         // torn write or a substituted file into an error rather than a
         // silently wrong object.
-        let actual = hash::object_id(&object)?;
+        let actual = hash::object_id_from_stored_bytes(&object, &bytes)?;
         if actual != *id {
             return Err(VcsError::ObjectCorrupted { id: *id, actual });
         }

--- a/crates/panproto-vcs/src/hash.rs
+++ b/crates/panproto-vcs/src/hash.rs
@@ -682,6 +682,70 @@ pub fn object_id(object: &crate::object::Object) -> Result<ObjectId, VcsError> {
     }
 }
 
+/// Compute an object's content address from its persisted `MessagePack` bytes.
+///
+/// Most object kinds use a canonical projection because their payload contains
+/// unordered maps or derived indices. The directly serialized kinds instead
+/// define their ID as the blake3 hash of the enum payload. Hashing that payload
+/// in place is both stricter and more compatible than deserializing and then
+/// serializing it again: a newer reader may supply default values for fields an
+/// older writer did not have, which changes the second serialization even
+/// though the stored bytes are intact.
+///
+/// Callers must deserialize `bytes` as `object` before calling this function.
+/// When the outer enum is not in the canonical one-entry-map representation,
+/// the function falls back to [`object_id`].
+///
+/// # Errors
+///
+/// Returns an error if a canonical projection cannot be serialized.
+pub fn object_id_from_stored_bytes(
+    object: &crate::object::Object,
+    bytes: &[u8],
+) -> Result<ObjectId, VcsError> {
+    use crate::object::Object;
+
+    let direct_variant = match object {
+        Object::Commit(_) => Some("Commit"),
+        Object::Tag(_) => Some("Tag"),
+        Object::Protocol(_) => Some("Protocol"),
+        Object::Expr(_) => Some("Expr"),
+        Object::Theory(_) => Some("Theory"),
+        _ => None,
+    };
+    if let Some(variant) = direct_variant
+        && let Some(payload) = messagepack_enum_payload(bytes, variant)
+    {
+        return Ok(ObjectId(blake3::hash(payload).into()));
+    }
+    object_id(object)
+}
+
+/// Return the payload of an externally tagged enum encoded by `rmp-serde`.
+///
+/// `Object` variants are encoded as a one-entry map whose key is a fixstr
+/// variant name and whose value occupies the remainder of the byte slice. All
+/// current and historical variant names fit in a fixstr. A shape outside that
+/// contract is left to the ordinary typed canonicalizer.
+fn messagepack_enum_payload<'a>(bytes: &'a [u8], expected_variant: &str) -> Option<&'a [u8]> {
+    const FIXMAP_ONE: u8 = 0x81;
+    const FIXSTR_MASK: u8 = 0xe0;
+    const FIXSTR_TAG: u8 = 0xa0;
+    const FIXSTR_LEN_MASK: u8 = 0x1f;
+
+    let (&map_marker, after_map) = bytes.split_first()?;
+    if map_marker != FIXMAP_ONE {
+        return None;
+    }
+    let (&string_marker, after_marker) = after_map.split_first()?;
+    if string_marker & FIXSTR_MASK != FIXSTR_TAG {
+        return None;
+    }
+    let name_len = usize::from(string_marker & FIXSTR_LEN_MASK);
+    let (variant, payload) = after_marker.split_at_checked(name_len)?;
+    (variant == expected_variant.as_bytes()).then_some(payload)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -814,6 +878,91 @@ mod tests {
         let h1 = hash_commit(&commit)?;
         let h2 = hash_commit(&commit)?;
         assert_eq!(h1, h2);
+        Ok(())
+    }
+
+    #[test]
+    fn stored_commit_id_uses_the_original_payload_shape() -> Result<(), Box<dyn std::error::Error>>
+    {
+        #[derive(Serialize)]
+        struct CommitBeforeUnverified<'a> {
+            schema_id: ObjectId,
+            parents: &'a [ObjectId],
+            migration_id: Option<ObjectId>,
+            protocol: &'a str,
+            author: &'a str,
+            timestamp: u64,
+            message: &'a str,
+            renames: &'a [panproto_gat::SiteRename],
+            protocol_id: Option<ObjectId>,
+            data_ids: &'a [ObjectId],
+            complement_ids: &'a [ObjectId],
+            edit_log_ids: &'a [ObjectId],
+            theory_ids: &'a BTreeMap<String, ObjectId>,
+            cst_complement_ids: &'a [ObjectId],
+        }
+
+        #[derive(Serialize)]
+        enum ObjectBeforeUnverified<'a> {
+            Commit(CommitBeforeUnverified<'a>),
+        }
+
+        let legacy = CommitBeforeUnverified {
+            schema_id: ObjectId::ZERO,
+            parents: &[],
+            migration_id: None,
+            protocol: "qvr",
+            author: "test-author",
+            timestamp: 1_234_567_890,
+            message: "historical commit",
+            renames: &[],
+            protocol_id: None,
+            data_ids: &[],
+            complement_ids: &[],
+            edit_log_ids: &[],
+            theory_ids: &BTreeMap::new(),
+            cst_complement_ids: &[],
+        };
+        let legacy_payload = rmp_serde::to_vec(&legacy)?;
+        let expected = ObjectId(blake3::hash(&legacy_payload).into());
+        let bytes = rmp_serde::to_vec(&ObjectBeforeUnverified::Commit(legacy))?;
+        let decoded: crate::object::Object = rmp_serde::from_slice(&bytes)?;
+
+        assert_ne!(
+            object_id(&decoded)?,
+            expected,
+            "reserializing adds the defaulted unverified field"
+        );
+        assert_eq!(
+            object_id_from_stored_bytes(&decoded, &bytes)?,
+            expected,
+            "stored payload bytes must retain their historical address"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn stored_commit_id_covers_every_persisted_byte() -> Result<(), Box<dyn std::error::Error>> {
+        let commit = CommitObject::builder(ObjectId::ZERO, "test", "author", "message")
+            .timestamp(1_234_567_890)
+            .build();
+        let object = crate::object::Object::Commit(commit);
+        let mut bytes = rmp_serde::to_vec(&object)?;
+        let expected = object_id_from_stored_bytes(&object, &bytes)?;
+        assert_eq!(expected, object_id(&object)?);
+
+        let message = b"message";
+        let offset = bytes
+            .windows(message.len())
+            .position(|window| window == message)
+            .ok_or("test message is absent from serialized commit")?;
+        bytes[offset] = b'M';
+        let decoded: crate::object::Object = rmp_serde::from_slice(&bytes)?;
+        assert_ne!(
+            object_id_from_stored_bytes(&decoded, &bytes)?,
+            expected,
+            "changing one persisted byte must change the verified ID"
+        );
         Ok(())
     }
 

--- a/crates/panproto-xrpc/src/client.rs
+++ b/crates/panproto-xrpc/src/client.rs
@@ -229,7 +229,7 @@ impl NodeClient {
         }
         let bytes = resp.bytes().await?;
         let obj: Object = rmp_serde::from_slice(&bytes)?;
-        let actual = panproto_vcs::hash::object_id(&obj)?;
+        let actual = panproto_vcs::hash::object_id_from_stored_bytes(&obj, &bytes)?;
         if actual != *id {
             return Err(XrpcError::ObjectMismatch {
                 requested: id.to_string(),


### PR DESCRIPTION
## Summary

Restore compatibility needed by indexed-family migrations: validate directly serialized content-addressed objects against their persisted MessagePack payload, preserving historical IDs when newer readers add defaulted fields, and make equation-variable inference follow the same implicit-argument calling convention as ordinary term checking.

## Changes

- Validate historical commit, tag, protocol, expression, and theory payloads without reserializing them; retain canonical typed hashing for object kinds with canonical projections.
- Apply persisted-byte validation to both filesystem reads and XRPC downloads while preserving substituted-object rejection.
- Infer fresh call-local metavariables for implicit operation inputs in equations and count only explicit arguments at call sites.
- Add regressions for pre-`unverified` commit payloads, byte-level tamper detection, and implicit-argument equation applications.
- Record both compatibility fixes under `## [Unreleased]`.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, schema, or migration semantics)
- [ ] Build / CI / release infrastructure
- [x] Documentation
- [ ] Refactor / internal cleanup
- [ ] Performance
- [ ] Security

## Affected surfaces

- [x] Rust crates (`crates/`) — `panproto-gat`, `panproto-vcs`, `panproto-xrpc`
- [ ] WASM boundary (`crates/panproto-wasm`)
- [ ] TypeScript SDK (`bindings/typescript`, `@panproto/core`)
- [ ] Python SDK (`bindings/python`, `crates/panproto-py`)
- [ ] Haskell SDK (`bindings/haskell`)
- [ ] Swift SDK (`bindings/swift`)
- [ ] C ABI (`crates/panproto-c`)
- [ ] CLI (`crates/panproto-cli`)
- [ ] Book (`book/src/`)
- [ ] CI workflows (`.github/workflows/`)
- [ ] Internal only (no published-surface change)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace` — delegated to PR CI
- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — delegated to PR CI
- [ ] `wasm-pack build crates/panproto-wasm --target web --dev` (not directly affected; delegated to PR CI)
- [ ] `cd bindings/typescript && pnpm install && pnpm test && pnpm exec tsc --noEmit` (not directly affected; delegated to PR CI)
- [ ] `cd bindings/python && uv run pytest tests/ -x` (not directly affected; delegated to PR CI)
- [x] Manual: 817 focused `panproto-gat`, `panproto-vcs`, and `panproto-xrpc` tests passed; the 64 Quivers historical-migration and Didactic QIEC lowering tests passed against local builds.

## Documentation

- [ ] Updated relevant `README.md` files
- [ ] Updated `book/src/` chapters if user-facing concepts changed
- [x] Updated CHANGELOG.md under `## [Unreleased]`
- [x] Updated docstrings / rustdoc on changed public items
- [ ] Documentation not required (pure refactor or internal only)

## Release coordination

- [ ] This PR bumps versions (`Cargo.toml`, `sdk/*/package.json`, etc.)
- [x] This PR adds or modifies published behavior and a CHANGELOG entry was added
- [ ] CI workflow change requires a one-time setup step on a third-party service

## Reviewer checklist

- [ ] Code compiles cleanly with `clippy -D warnings`
- [ ] Tests cover the change and existing tests still pass
- [ ] Public API changes are documented and CHANGELOG-noted
- [ ] No secrets, tokens, or PII in the diff
- [ ] No `unwrap` / `expect` / `panic!` introduced on the WASM or SDK boundary
- [ ] No `--no-verify`, `--allow-dirty`, or `unsafe` without explicit justification in this PR description
- [ ] Diff size is reviewable; if not, this PR is split into smaller pieces