### PR TITLE
chore(release): prepare 0.74.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to panproto will be documented in this file.
 
 ## [Unreleased]
 
+## [0.74.2] - 2026-09-12
+
 ### Bug Fixes
 
 - **Historical content-addressed objects retain their original identities** (`panproto-vcs`, `panproto-xrpc`): filesystem and remote reads validated a decoded object by serializing it again with the current type definition. A commit written before the `unverified` field existed therefore gained an empty field during decoding and hashed to a new ID, so intact repositories created by Panproto 0.58 were reported as corrupted by 0.74.1. Directly serialized object kinds are now validated against the payload bytes that were actually stored or received. Every byte remains covered by blake3, substituted objects are still refused, and current writes keep their existing addresses.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "book-doctest-stub"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "anyhow",
  "miette",
@@ -1832,7 +1832,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-c"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "ciborium",
  "git2",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "divan",
  "insta",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-cli"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-core"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "divan",
  "panproto-check",
@@ -1919,7 +1919,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-dsl-eval"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "nickel-lang",
  "serde",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "divan",
  "proptest",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "chumsky",
  "divan",
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "divan",
  "miette",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat-macros"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "panproto-gat",
  "proc-macro2",
@@ -1979,7 +1979,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "divan",
  "git2",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-git-remote"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "git2",
  "miette",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "cc",
  "divan",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-all"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-data"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-devops"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-functional"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-jvm"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-mobile"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-music"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-scripting"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-systems"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars-web"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "panproto-grammars",
  "pyo3",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-integration-tests"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "panproto-check",
  "panproto-core",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-io"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "bumpalo",
  "divan",
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "divan",
  "insta",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens-dsl"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "divan",
  "miette",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "blake3",
  "divan",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "divan",
  "memchr",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-project"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "blake3",
  "divan",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "blake3",
  "divan",
@@ -2307,7 +2307,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-py"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "git2",
  "panproto-core",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-theory-dsl"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "divan",
  "miette",
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-vcs"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "blake3",
  "divan",
@@ -2386,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-wasm"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "divan",
  "panproto-core",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-xrpc"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "divan",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.74.1"
+version = "0.74.2"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -109,27 +109,27 @@ tree-sitter = "0.26"
 tree-sitter-tags = "0.26"
 
 # Workspace crates
-panproto-gat = { version = "0.74.1", path = "crates/panproto-gat" }
-panproto-gat-macros = { version = "0.74.1", path = "crates/panproto-gat-macros" }
-panproto-schema = { version = "0.74.1", path = "crates/panproto-schema" }
-panproto-inst = { version = "0.74.1", path = "crates/panproto-inst" }
-panproto-mig = { version = "0.74.1", path = "crates/panproto-mig" }
-panproto-lens = { version = "0.74.1", path = "crates/panproto-lens" }
-panproto-dsl-eval = { version = "0.74.1", path = "crates/panproto-dsl-eval" }
-panproto-lens-dsl = { version = "0.74.1", path = "crates/panproto-lens-dsl" }
-panproto-theory-dsl = { version = "0.74.1", path = "crates/panproto-theory-dsl" }
-panproto-check = { version = "0.74.1", path = "crates/panproto-check" }
-panproto-protocols = { version = "0.74.1", path = "crates/panproto-protocols" }
-panproto-core = { version = "0.74.1", path = "crates/panproto-core" }
-panproto-io = { version = "0.74.1", path = "crates/panproto-io" }
-panproto-vcs = { version = "0.74.1", path = "crates/panproto-vcs" }
-panproto-expr = { version = "0.74.1", path = "crates/panproto-expr" }
-panproto-expr-parser = { version = "0.74.1", path = "crates/panproto-expr-parser" }
-panproto-grammars = { version = "0.74.1", path = "crates/panproto-grammars", default-features = false }
-panproto-parse = { version = "0.74.1", path = "crates/panproto-parse" }
-panproto-project = { version = "0.74.1", path = "crates/panproto-project" }
-panproto-git = { version = "0.74.1", path = "crates/panproto-git" }
-panproto-xrpc = { version = "0.74.1", path = "crates/panproto-xrpc" }
+panproto-gat = { version = "0.74.2", path = "crates/panproto-gat" }
+panproto-gat-macros = { version = "0.74.2", path = "crates/panproto-gat-macros" }
+panproto-schema = { version = "0.74.2", path = "crates/panproto-schema" }
+panproto-inst = { version = "0.74.2", path = "crates/panproto-inst" }
+panproto-mig = { version = "0.74.2", path = "crates/panproto-mig" }
+panproto-lens = { version = "0.74.2", path = "crates/panproto-lens" }
+panproto-dsl-eval = { version = "0.74.2", path = "crates/panproto-dsl-eval" }
+panproto-lens-dsl = { version = "0.74.2", path = "crates/panproto-lens-dsl" }
+panproto-theory-dsl = { version = "0.74.2", path = "crates/panproto-theory-dsl" }
+panproto-check = { version = "0.74.2", path = "crates/panproto-check" }
+panproto-protocols = { version = "0.74.2", path = "crates/panproto-protocols" }
+panproto-core = { version = "0.74.2", path = "crates/panproto-core" }
+panproto-io = { version = "0.74.2", path = "crates/panproto-io" }
+panproto-vcs = { version = "0.74.2", path = "crates/panproto-vcs" }
+panproto-expr = { version = "0.74.2", path = "crates/panproto-expr" }
+panproto-expr-parser = { version = "0.74.2", path = "crates/panproto-expr-parser" }
+panproto-grammars = { version = "0.74.2", path = "crates/panproto-grammars", default-features = false }
+panproto-parse = { version = "0.74.2", path = "crates/panproto-parse" }
+panproto-project = { version = "0.74.2", path = "crates/panproto-project" }
+panproto-git = { version = "0.74.2", path = "crates/panproto-git" }
+panproto-xrpc = { version = "0.74.2", path = "crates/panproto-xrpc" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/bindings/haskell/panproto.cabal
+++ b/bindings/haskell/panproto.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               panproto
-version:             0.74.1
+version:             0.74.2
 synopsis:           Haskell bindings for panproto
 description:
   Haskell bindings for panproto, a schematic version-control system for

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panproto/core",
-  "version": "0.74.1",
+  "version": "0.74.2",
   "description": "Schematic version control with panproto (TypeScript SDK)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/crates/panproto-grammars-all/Cargo.toml
+++ b/crates/panproto-grammars-all/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-all` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.74.1", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
+panproto-grammars = { version = "=0.74.2", path = "../panproto-grammars", default-features = false, features = ["group-all"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-data/Cargo.toml
+++ b/crates/panproto-grammars-data/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-data` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.74.1", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
+panproto-grammars = { version = "=0.74.2", path = "../panproto-grammars", default-features = false, features = ["group-data"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-devops/Cargo.toml
+++ b/crates/panproto-grammars-devops/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-devops` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.74.1", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
+panproto-grammars = { version = "=0.74.2", path = "../panproto-grammars", default-features = false, features = ["group-devops"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-functional/Cargo.toml
+++ b/crates/panproto-grammars-functional/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-functional` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.74.1", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
+panproto-grammars = { version = "=0.74.2", path = "../panproto-grammars", default-features = false, features = ["group-functional"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-jvm/Cargo.toml
+++ b/crates/panproto-grammars-jvm/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-jvm` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.74.1", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
+panproto-grammars = { version = "=0.74.2", path = "../panproto-grammars", default-features = false, features = ["group-jvm"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-mobile/Cargo.toml
+++ b/crates/panproto-grammars-mobile/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-mobile` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.74.1", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
+panproto-grammars = { version = "=0.74.2", path = "../panproto-grammars", default-features = false, features = ["group-mobile"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-music/Cargo.toml
+++ b/crates/panproto-grammars-music/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-music` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.74.1", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
+panproto-grammars = { version = "=0.74.2", path = "../panproto-grammars", default-features = false, features = ["group-music"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-scripting/Cargo.toml
+++ b/crates/panproto-grammars-scripting/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-scripting` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.74.1", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
+panproto-grammars = { version = "=0.74.2", path = "../panproto-grammars", default-features = false, features = ["group-scripting"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-systems/Cargo.toml
+++ b/crates/panproto-grammars-systems/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-systems` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.74.1", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
+panproto-grammars = { version = "=0.74.2", path = "../panproto-grammars", default-features = false, features = ["group-systems"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/crates/panproto-grammars-web/Cargo.toml
+++ b/crates/panproto-grammars-web/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # `group-web` grammars, not the workspace-default `group-core`.
 # Workspace inheritance is bypassed because the workspace dep
 # doesn't pin default-features.
-panproto-grammars = { version = "=0.74.1", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
+panproto-grammars = { version = "=0.74.2", path = "../panproto-grammars", default-features = false, features = ["group-web"] }
 pyo3 = { workspace = true }
 tree-sitter = { workspace = true }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -271,7 +271,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-expr"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "miette",
  "panproto-expr",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "bumpalo",
  "panproto-expr",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.74.1"
+version = "0.74.2"
 dependencies = [
  "blake3",
  "panproto-expr",


### PR DESCRIPTION
## Summary

Prepare the Panproto 0.74.2 patch release after the historical object-identity and implicit-equation compatibility fixes merged in #311.

## Changes

- Bump every version-declaring Rust crate and language binding from 0.74.1 to 0.74.2 with the repository release script.
- Refresh the workspace and fuzz lockfiles.
- Move the two compatibility fixes from `Unreleased` into the dated 0.74.2 changelog section.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, schema, or migration semantics)
- [x] Build / CI / release infrastructure
- [x] Documentation
- [ ] Refactor / internal cleanup
- [ ] Performance
- [ ] Security

## Affected surfaces

- [x] Rust crates (`crates/`) — all published crates, version metadata only
- [x] WASM boundary (`crates/panproto-wasm`) — workspace version only
- [x] TypeScript SDK (`bindings/typescript`, `@panproto/core`) — version only
- [x] Python SDK (`bindings/python`, `crates/panproto-py`) — workspace version only
- [x] Haskell SDK (`bindings/haskell`) — version only
- [x] Swift SDK (`bindings/swift`) — workspace release coordination
- [x] C ABI (`crates/panproto-c`) — workspace version only
- [x] CLI (`crates/panproto-cli`) — workspace version only
- [ ] Book (`book/src/`)
- [ ] CI workflows (`.github/workflows/`)
- [ ] Internal only (no published-surface change)

## Test plan

- [x] `.venv/bin/python .github/scripts/check_version_consistency.py`
- [x] `git diff --check`
- [ ] Full cross-platform verification — delegated to PR CI and required again by tag workflows before publication

## Documentation

- [ ] Updated relevant `README.md` files
- [ ] Updated `book/src/` chapters
- [x] Updated `CHANGELOG.md` with `0.74.2` and `2026-09-12`
- [ ] Updated docstrings / rustdoc
- [ ] Documentation not required

## Release coordination

- [x] This PR bumps versions (`Cargo.toml`, language bindings, and lockfiles)
- [x] Published behavior and its changelog entries merged in #311
- [ ] CI workflow change requires a one-time setup step on a third-party service

## Reviewer checklist

- [ ] Code compiles cleanly with `clippy -D warnings`
- [ ] Tests cover the change and existing tests still pass
- [ ] Public API changes are documented and CHANGELOG-noted
- [ ] No secrets, tokens, or PII in the diff
- [ ] No `unwrap` / `expect` / `panic!` introduced on the WASM boundary
- [ ] No `--no-verify`, `--allow-dirty`, or `unsafe` without explicit justification
- [ ] Diff size is reviewable